### PR TITLE
Error associated type bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ https://www.kernel.org/doc/Documentation/i2c/dev-interface
 """
 
 [dependencies]
-libc = "0.2.7"
-bitflags = "0.5"
-byteorder = "0.4.2"
-nix = "0.5"
+libc = "^0.2.7"
+bitflags = "^0.5.0"
+byteorder = "^0.4.2"
+nix = "^0.5.0"
 
 [dev-dependencies]
-docopt = "^0.6"
+docopt = "^0.6.78"

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use byteorder::{ByteOrder, LittleEndian};
+use std::error::Error;
 
 /// Interface to an I2C Slave Device from an I2C Master
 ///
@@ -14,7 +15,7 @@ use byteorder::{ByteOrder, LittleEndian};
 /// in use and the address of the slave device.  The trait is based on the
 /// Linux i2cdev interface.
 pub trait I2CDevice {
-    type Error;
+    type Error: Error;
 
     /// Read data from the device to fill the provided slice
     fn read(&mut self, data: &mut [u8]) -> Result<(), Self::Error>;

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -82,8 +82,6 @@ impl Error for LinuxI2CError {
     }
 }
 
-type I2CResult<T> = Result<T, LinuxI2CError>;
-
 impl AsRawFd for LinuxI2CDevice {
     fn as_raw_fd(&self) -> RawFd {
         self.devfile.as_raw_fd()
@@ -118,7 +116,7 @@ impl LinuxI2CDevice {
     /// (it is done internally).  Calling this method is only
     /// necessary if you need to change the slave device and you do
     /// not want to create a new device.
-    fn set_slave_address(&mut self, slave_address: u16) -> I2CResult<()> {
+    fn set_slave_address(&mut self, slave_address: u16) -> Result<(), LinuxI2CError> {
         try!(ffi::i2c_set_slave_address(self.as_raw_fd(), slave_address));
         self.slave_address = slave_address;
         Ok(())
@@ -129,17 +127,17 @@ impl I2CDevice for LinuxI2CDevice {
     type Error = LinuxI2CError;
 
     /// Read data from the device to fill the provided slice
-    fn read(&mut self, data: &mut [u8]) -> I2CResult<()> {
+    fn read(&mut self, data: &mut [u8]) -> Result<(), LinuxI2CError> {
         self.devfile.read(data).map_err(From::from).map(drop)
     }
 
     /// Write the provided buffer to the device
-    fn write(&mut self, data: &[u8]) -> I2CResult<()> {
+    fn write(&mut self, data: &[u8]) -> Result<(), LinuxI2CError> {
         self.devfile.write(data).map_err(From::from).map(drop)
     }
 
     /// This sends a single bit to the device, at the place of the Rd/Wr bit
-    fn smbus_write_quick(&mut self, bit: bool) -> I2CResult<()> {
+    fn smbus_write_quick(&mut self, bit: bool) -> Result<(), LinuxI2CError> {
         ffi::i2c_smbus_write_quick(self.as_raw_fd(), bit).map_err(From::from)
     }
 
@@ -148,7 +146,7 @@ impl I2CDevice for LinuxI2CDevice {
     /// Some devices are so simple that this interface is enough; for
     /// others, it is a shorthand if you want to read the same register as in
     /// the previous SMBus command.
-    fn smbus_read_byte(&mut self) -> I2CResult<u8> {
+    fn smbus_read_byte(&mut self) -> Result<u8, LinuxI2CError> {
         ffi::i2c_smbus_read_byte(self.as_raw_fd()).map_err(From::from)
     }
 
@@ -156,36 +154,36 @@ impl I2CDevice for LinuxI2CDevice {
     ///
     /// This is the opposite operation as smbus_read_byte.  As with read_byte,
     /// no register is specified.
-    fn smbus_write_byte(&mut self, value: u8) -> I2CResult<()> {
+    fn smbus_write_byte(&mut self, value: u8) -> Result<(), LinuxI2CError> {
         ffi::i2c_smbus_write_byte(self.as_raw_fd(), value).map_err(From::from)
     }
 
     /// Read a single byte from a device, from a designated register
     ///
     /// The register is specified through the Comm byte.
-    fn smbus_read_byte_data(&mut self, register: u8) -> I2CResult<u8> {
+    fn smbus_read_byte_data(&mut self, register: u8) -> Result<u8, LinuxI2CError> {
         ffi::i2c_smbus_read_byte_data(self.as_raw_fd(), register).map_err(From::from)
     }
 
     /// Write a single byte to a specific register on a device
     ///
     /// The register is specified through the Comm byte.
-    fn smbus_write_byte_data(&mut self, register: u8, value: u8) -> I2CResult<()> {
+    fn smbus_write_byte_data(&mut self, register: u8, value: u8) -> Result<(), LinuxI2CError> {
         ffi::i2c_smbus_write_byte_data(self.as_raw_fd(), register, value).map_err(From::from)
     }
 
     /// Read 2 bytes form a given register on a device
-    fn smbus_read_word_data(&mut self, register: u8) -> I2CResult<u16> {
+    fn smbus_read_word_data(&mut self, register: u8) -> Result<u16, LinuxI2CError> {
         ffi::i2c_smbus_read_word_data(self.as_raw_fd(), register).map_err(From::from)
     }
 
     /// Write 2 bytes to a given register on a device
-    fn smbus_write_word_data(&mut self, register: u8, value: u16) -> I2CResult<()> {
+    fn smbus_write_word_data(&mut self, register: u8, value: u16) -> Result<(), LinuxI2CError> {
         ffi::i2c_smbus_write_word_data(self.as_raw_fd(), register, value).map_err(From::from)
     }
 
     /// Select a register, send 16 bits of data to it, and read 16 bits of data
-    fn smbus_process_word(&mut self, register: u8, value: u16) -> I2CResult<u16> {
+    fn smbus_process_word(&mut self, register: u8, value: u16) -> Result<u16, LinuxI2CError> {
         ffi::i2c_smbus_process_call(self.as_raw_fd(), register, value).map_err(From::from)
     }
 
@@ -194,7 +192,7 @@ impl I2CDevice for LinuxI2CDevice {
     /// The actual number of bytes available to read is returned in the count
     /// byte.  This code returns a correctly sized vector containing the
     /// count bytes read from the device.
-    fn smbus_read_block_data(&mut self, register: u8) -> I2CResult<Vec<u8>> {
+    fn smbus_read_block_data(&mut self, register: u8) -> Result<Vec<u8>, LinuxI2CError> {
         ffi::i2c_smbus_read_block_data(self.as_raw_fd(), register).map_err(From::from)
     }
 
@@ -203,13 +201,13 @@ impl I2CDevice for LinuxI2CDevice {
     /// The opposite of the Block Read command, this writes up to 32 bytes to
     /// a device, to a designated register that is specified through the
     /// Comm byte. The amount of data is specified in the Count byte.
-    fn smbus_write_block_data(&mut self, register: u8, values: &[u8]) -> I2CResult<()> {
+    fn smbus_write_block_data(&mut self, register: u8, values: &[u8]) -> Result<(), LinuxI2CError> {
         ffi::i2c_smbus_write_block_data(self.as_raw_fd(), register, values).map_err(From::from)
     }
 
     /// Select a register, send 1 to 31 bytes of data to it, and reads
     /// 1 to 31 bytes of data from it.
-    fn smbus_process_block(&mut self, register: u8, values: &[u8]) -> I2CResult<()> {
+    fn smbus_process_block(&mut self, register: u8, values: &[u8]) -> Result<(), LinuxI2CError> {
         ffi::i2c_smbus_write_i2c_block_data(self.as_raw_fd(), register, values).map_err(From::from)
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -8,6 +8,7 @@
 
 use ffi;
 use core::I2CDevice;
+use std::error::Error;
 use std::path::Path;
 use std::fs::File;
 use std::fmt;
@@ -22,6 +23,7 @@ pub struct LinuxI2CDevice {
     slave_address: u16,
 }
 
+#[derive(Debug)]
 pub enum LinuxI2CError {
     Nix(nix::Error),
     Io(io::Error),
@@ -55,11 +57,27 @@ impl From<LinuxI2CError> for io::Error {
     }
 }
 
-impl fmt::Debug for LinuxI2CError {
+impl fmt::Display for LinuxI2CError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            LinuxI2CError::Nix(ref e) => fmt::Debug::fmt(e, f),
-            LinuxI2CError::Io(ref e) => fmt::Debug::fmt(e, f),
+            LinuxI2CError::Nix(ref e) => fmt::Display::fmt(e, f),
+            LinuxI2CError::Io(ref e) => fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl Error for LinuxI2CError {
+    fn description(&self) -> &str {
+        match *self {
+            LinuxI2CError::Io(ref e) => e.description(),
+            LinuxI2CError::Nix(ref e) => e.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            LinuxI2CError::Io(ref e) => Some(e),
+            LinuxI2CError::Nix(ref e) => Some(e),
         }
     }
 }

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -6,6 +6,8 @@
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::error::Error;
+
 pub mod adxl345_accelerometer;
 pub mod mpl115a2_barometer;
 pub mod nunchuck;
@@ -23,7 +25,7 @@ pub struct AccelerometerSample {
 
 /// Trait for sensors that provide access to accelerometer readings (3-axis)
 pub trait Accelerometer {
-    type Error;
+    type Error: Error;
 
     /// Grab an accelerometer sample from the device
     fn accelerometer_sample(&mut self) -> Result<AccelerometerSample, Self::Error>;
@@ -31,7 +33,7 @@ pub trait Accelerometer {
 
 /// Trait for sensors that provide access to temperature readings
 pub trait Thermometer {
-    type Error;
+    type Error: Error;
 
     /// Get na temperature from the sensor in degrees celsisus
     ///
@@ -42,7 +44,7 @@ pub trait Thermometer {
 
 /// Trait for sensors that provide access to pressure readings
 pub trait Barometer {
-    type Error;
+    type Error: Error;
 
     /// Get a pressure reading from the sensor in kPa
     ///

--- a/src/sensors/mpl115a2_barometer.rs
+++ b/src/sensors/mpl115a2_barometer.rs
@@ -81,7 +81,7 @@ impl MPL115A2Coefficients {
     /// This should be built from a read of registers 0x04-0x0B in
     /// order.  This gets the raw, unconverted value of each
     /// coefficient.
-    pub fn new<E>(i2cdev: &mut I2CDevice<Error = E>) -> Result<MPL115A2Coefficients, E> {
+    pub fn new<E: Error>(i2cdev: &mut I2CDevice<Error=E>) -> Result<MPL115A2Coefficients, E> {
         let mut buf: [u8; 8] = [0; 8];
         try!(i2cdev.write(&[REGISTER_ADDR_A0]));
         try!(i2cdev.read(&mut buf));
@@ -97,7 +97,7 @@ impl MPL115A2Coefficients {
 
 impl MPL115A2RawReading {
     /// Create a new reading from the provided I2C Device
-    pub fn new<E>(i2cdev: &mut I2CDevice<Error = E>) -> Result<MPL115A2RawReading, E> {
+    pub fn new<E: Error>(i2cdev: &mut I2CDevice<Error=E>) -> Result<MPL115A2RawReading, E> {
         // tell the chip to do an ADC read so we can get updated values
         try!(i2cdev.smbus_write_byte_data(REGISTER_ADDR_START_CONVERSION, 0x00));
 

--- a/src/sensors/nunchuck.rs
+++ b/src/sensors/nunchuck.rs
@@ -9,7 +9,9 @@
 // Reads data from Wii Nunchuck
 
 use std::io::prelude::*;
+use std::error::Error;
 use std::thread;
+use std::fmt;
 
 use core::I2CDevice;
 
@@ -19,6 +21,31 @@ pub const NUNCHUCK_SLAVE_ADDR: u16 = 0x52;
 pub enum NunchuckError<E> {
     Error(E),
     ParseError,
+}
+
+impl<E: Error> fmt::Display for NunchuckError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            NunchuckError::Error(ref e) => fmt::Display::fmt(e, f),
+            NunchuckError::ParseError => fmt::Display::fmt(self.description(), f),
+        }
+    }
+}
+
+impl<E: Error> Error for NunchuckError<E> {
+    fn description(&self) -> &str {
+        match *self {
+            NunchuckError::Error(ref e) => e.description(),
+            NunchuckError::ParseError => "Unable to Parse Data",
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            NunchuckError::Error(ref e) => Some(e),
+            NunchuckError::ParseError => None,
+        }
+    }
 }
 
 // TODO: Move Nunchuck code out to be an actual sensor and add tests


### PR DESCRIPTION
Blocked on `nix` publishing its latest changes to crates.io. In the case that `no_std` is supported in the future, the `Error` trait bound may be substituted with `Debug + Display` or similar.