### PR TITLE
Doc fixes and cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ https://www.kernel.org/doc/Documentation/i2c/dev-interface
 libc = "^0.2.7"
 bitflags = "^0.5.0"
 byteorder = "^0.4.2"
-nix = "^0.5.0"
+nix = "^0.6.0"
 
 [dev-dependencies]
 docopt = "^0.6.78"
-skeptic = "0.4"
+skeptic = "^0.5"
 
 [build-dependencies]
-skeptic = "0.4"
+skeptic = "^0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 
 name = "i2cdev"
+build = "build.rs"
 version = "0.3.0"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
@@ -21,3 +22,7 @@ nix = "^0.5.0"
 
 [dev-dependencies]
 docopt = "^0.6.78"
+skeptic = "0.4"
+
+[build-dependencies]
+skeptic = "0.4"

--- a/README.md
+++ b/README.md
@@ -20,56 +20,44 @@ The source includes an example of using the library to talk to a Wii
 Nunchuck (which has an i2c interface).
 [Go View the Example](https://github.com/rust-embedded/rust-i2cdev/blob/master/examples/nunchuck.rs).
 
-Here's a real quick example showing the guts of how you create a
+Here's a real quick example showing the guts of how you create
 device and start talking to it...  This device only requires basic
 functions (read/write) which are done via the Read/Write traits (if
 you actually want to use the Wii Nunchuck you should use
 [`i2cdev::sensors::nunchuck::Nunchuck`][nunchuck]:
 
-```rust
+```rust,no_run
 extern crate i2cdev;
-use i2cdev::*;
+
 use std::thread;
+use std::time::Duration;
+
+use i2cdev::core::*;
+use i2cdev::linux::{LinuxI2CDevice, LinuxI2CError};
 
 const NUNCHUCK_SLAVE_ADDR: u16 = 0x52;
 
 // real code should probably not use unwrap()
-fn i2cfun() -> Result<(), I2CError> {
-    let mut dev = try!(I2CDevice::new("/dev/i2c-1", NUNCHUCK_SLAVE_ADDR));
+fn i2cfun() -> Result<(), LinuxI2CError> {
+    let mut dev = try!(LinuxI2CDevice::new("/dev/i2c-1", NUNCHUCK_SLAVE_ADDR));
 
     // init sequence
-    try!(self.i2cdev.smbus_write_byte_data(0xF0, 0x55));
-    try!(self.i2cdev.smbus_write_byte_data(0xFB, 0x00));
-    thread::sleep_ms(100);
+    try!(dev.smbus_write_byte_data(0xF0, 0x55));
+    try!(dev.smbus_write_byte_data(0xFB, 0x00));
+    thread::sleep(Duration::from_millis(100));
 
     loop {
-        let mut buf: [u8: 6] = [0: 6];
-        self.i2cdev.smbus_write_byte(0x00).unwrap();
-        thread::sleep_ms(10);
-        self.i2cdev.read(&mut buf).unwrap();
+        let mut buf: [u8; 6] = [0; 6];
+        dev.smbus_write_byte(0x00).unwrap();
+        thread::sleep(Duration::from_millis(10));
+        dev.read(&mut buf).unwrap();
         println!("Reading: {:?}", buf);
     }
 }
 ```
 
 In addition to the Read/Write traits, the following methods are
-available via the I2CSMBus trait:
-
-```rust
-pub trait I2CSMBus {
-    fn smbus_write_quick(&self, bit: bool) -> Result<(), Error>;
-    fn smbus_read_byte(&self) -> Result<u8, Error>;
-    fn smbus_write_byte(&self, value: u8) -> Result<(), Error>;
-    fn smbus_read_byte_data(&self, register: u8) -> Result<u8, Error>;
-    fn smbus_write_byte_data(&self, register: u8, value: u8) -> Result<(), Error>;
-    fn smbus_read_word_data(&self, register: u8) -> Result<u16, Error>;
-    fn smbus_write_word_data(&self, register: u8, value: u16) -> Result<(), Error>;
-    fn smbus_process_word(&self, register: u8, value: u16) -> Result<u16, Error>;
-    fn smbus_read_block_data(&self, register: u8) -> Result<Vec<u8>, Error>;
-    fn smbus_write_block_data(&self, register: u8, values: &[u8]) -> Result<(), Error>;
-    fn smbus_process_block(&self, register: u8, values: &[u8]) -> Result<(), Error>;
-}
-```
+available via the [I2CDevice trait](https://rust-embedded.github.io/rust-i2cdev/i2cdev/core/trait.I2CDevice.html).
 
 [nunchuck]: http://rust-embedded.github.io/rust-i2cdev/i2cdev/sensors/nunchuck/struct.Nunchuck.html
 
@@ -82,7 +70,7 @@ The following features are implemented and planned for the library:
 - [x] Implement the Write trait
 - [x] Implement SMBus Methods
 - [x] Add Tests/Example for SMBus Methods
-- [/] Add sensor library for handy sensors (and examples)
+- [x] Add sensor library for handy sensors (and examples)
 - [ ] Add higher-level APIs/Macros for simplifying access to devices
       with large register sets
 - [ ] Add Support for Non-SMBus ioctl methods
@@ -94,33 +82,12 @@ Cross Compiling
 
 Most likely, the machine you are running on is not your development
 machine (although it could be).  In those cases, you will need to
-cross-compile.  The following basic instructions should work for the
-raspberry pi or beaglebone black:
-
-1. Install rust and cargo
-2. Install an appropriate cross compiler.  On an Ubuntu system, this
-   can be done by doing `sudo apt-get install g++-arm-linux-gnueabihf`.
-3. Build or install rust for your target.  This is necessary in order
-   to have libstd available for your target.  For arm-linux-gnueabihf,
-   you can find binaries at https://github.com/japaric/ruststrap.
-   With this approach or building it yourself, you will need to copy
-   the ${rust}/lib/rustlib/arm-unknown-linux-gnueabihf to your system
-   rust library folder (it is namespaced by triple, so it shouldn't
-   break anything).
-4. Tell cargo how to link by adding the lines below to your
-   ~/.cargo/config file.
-5. Run your build `cargo build --target=arm-unknown-linux-gnueabi`.
-
-The following snippet added to my ~/.cargo/config worked for me:
-
-```
-[target.arm-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
-```
+cross-compile.  See https://github.com/japaric/rust-cross for pointers.
 
 License
 -------
 
+```
 Copyright (c) 2015, Paul Osborne <ospbau@gmail.com>
 
 Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -128,3 +95,4 @@ http://www.apache.org/license/LICENSE-2.0> or the MIT license
 <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 option.  This file may not be copied, modified, or distributed
 except according to those terms.
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example/API
 
 The source includes an example of using the library to talk to a Wii
 Nunchuck (which has an i2c interface).
-[Go View the Example Example](https://github.com/rust-embedded/rust-i2cdev/blob/master/examples/nunchuck.rs).
+[Go View the Example](https://github.com/rust-embedded/rust-i2cdev/blob/master/examples/nunchuck.rs).
 
 Here's a real quick example showing the guts of how you create a
 device and start talking to it...  This device only requires basic

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+// Copyright 2016, Paul Osborne <osbpau@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate skeptic;
+
+fn main() {
+    // generate tests for README.md using skeptic
+    skeptic::generate_doc_tests(&["README.md"]);
+}

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -26,14 +26,12 @@ const USAGE: &'static str = "
 Reading sensor data from a variety of sensors
 
 Usage:
-  sensors \
-                             <device>
+  sensors <device>
   sensors (-h | --help)
   sensors --version
 
 Options:
-  -h \
-                             --help    Show this help text.
+  -h --help    Show this help text.
   --version    Show version.
 ";
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -23,10 +23,6 @@ pub trait I2CDevice {
     /// Write the provided buffer to the device
     fn write(&mut self, data: &[u8]) -> Result<(), Self::Error>;
 
-    // The following implementations are defaults that seek to match the
-    // kernel implementation where possible.
-    //
-
     /// This sends a single bit to the device, at the place of the Rd/Wr bit
     fn smbus_write_quick(&mut self, bit: bool) -> Result<(), Self::Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,10 @@ extern crate nix;
 
 mod ffi;
 pub mod core;
-pub mod linux;
 pub mod sensors;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub mod linux;
 
 #[cfg(test)]
 pub mod mock;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -8,7 +8,7 @@
 use core::I2CDevice;
 use std::io;
 
-type I2CResult<T> = io::Result<T>;
+pub type I2CResult<T> = io::Result<T>;
 
 pub struct I2CRegisterMap {
     registers: [u8; 0xFF],

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,0 +1,9 @@
+// Copyright 2016, Paul Osborne <osbpau@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
+
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
CC @nastevens 

Tests will fail until `no_run` is supported in skeptic.  I opened up a PR for that earlier this evening: https://github.com/brson/rust-skeptic/pull/5