### PR TITLE
Add support for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: rust
 sudo: false
+
+os:
+- linux
+- osx
+
 env:
   global:
   - secure: gZdvTl4i1QfHQaCUPcVpnLtlrsE4WldSm99AD9C9jiMgjlzhhI4kQmIhssNFhA1BWDW6qDazrKnw4ZT1GA/rlmGSpLxs2lfBNTjPF0CJMVSTEQ1OaFcDGajziTTCSMh7jDml1/CFHuGSc+rS4bNv5wu0bj+pz3ZSRSuB7Vgoa0aRD8JQKc+phnIoXMCCfIh9vxlXWvO9mDMoR84/B35/gN/vWIi3+uuHgvvdKMK8qBbJ0ne25kOIA5CpXzJmOBFHCGblVQM4+AiTWvWtoXJjMcJXn9HZ2g3HWhrnixG07Ee1RrjUPo25tsxrBowHSGq9Bbo+jzmOmx03CRnCBHyXk6e12MXrfVFWRdmFaf7Sl/RBlz8Y2BRgktp8ihB6JQmjNuRptE4RdnWn6CU9liSQ5nzzGEl2ZtBrzN9GR3qyhq5W9e09v93MZfBr0svp/rtBoqDANfkpxvmWqtgO3fjN1fdf092sEcQfq3d7e6NaLSWKkI6V9wJnJ9UulPDAaqGVm8RrA9b0vJR6ouCf5ChZgYirz6LW5uPpMkf+cjESU9JxnX9xVB8tfPSoNrPKolRC/WRZ8gPbRmx0vF4wrDk8z9Fks5nHGwDsPdYe60Qe8m6ZclncCkpUzy2yAZWe/kiDaseOwNbSqEUZW80hLyHpuGi1IFpGBQfc8mYMPvqOHa8=
@@ -9,7 +14,7 @@ script:
   - cargo test --verbose
   - cargo doc
 
-after_success: '[ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ] &&
+after_success: '[ $TRAVIS_OS_NAME == linux ] && [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ] &&
   echo "<meta http-equiv=refresh content=0;url=i2cdev/index.html>" > target/doc/index.html
   && sudo pip install ghp-import && ghp-import -n target/doc && git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
   gh-pages'

--- a/examples/nunchuck.rs
+++ b/examples/nunchuck.rs
@@ -11,11 +11,13 @@
 extern crate i2cdev;
 extern crate docopt;
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use i2cdev::linux::*;
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use i2cdev::sensors::nunchuck::*;
+
 use std::env::args;
 use docopt::Docopt;
-
 
 const USAGE: &'static str = "
 Reading Wii Nunchuck data via Linux i2cdev.
@@ -30,7 +32,10 @@ Options:
   --version    Show version.
 ";
 
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn main() {}
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn main() {
     let args = Docopt::new(USAGE)
                    .and_then(|d| d.argv(args().into_iter()).parse())

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -21,6 +21,7 @@ use docopt::Docopt;
 use i2cdev::sensors::{Thermometer, Barometer, Accelerometer};
 use i2cdev::sensors::mpl115a2_barometer::*;
 use i2cdev::sensors::adxl345_accelerometer::*;
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use i2cdev::linux::*;
 
 const USAGE: &'static str = "
@@ -36,6 +37,10 @@ Options:
   --version    Show version.
 ";
 
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn main() {}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn main() {
     let args = Docopt::new(USAGE)
                    .and_then(|d| d.argv(args().into_iter()).parse())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@ extern crate bitflags;
 #[macro_use]
 extern crate nix;
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod ffi;
+
 pub mod core;
 pub mod sensors;
 


### PR DESCRIPTION
This adds conditional compilation directives for the `ffi` module so that one can use and mock the `I2cDevice` trait on OSX. Additionally, it adds conditional compilation directives to the example programs so that they build successfully when invoking `cargo test`.

Finally, it adds Travis CI testing coverage for OSX.

-----------

I think using the `cfg-if` crate would make the example programs look a little nicer, but wasn't sure if adding a new dependency was welcome or even worth it.