### PR TITLE
Fix celsisus to celsius

### DIFF
--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -35,7 +35,7 @@ pub trait Accelerometer {
 pub trait Thermometer {
     type Error: Error;
 
-    /// Get na temperature from the sensor in degrees celsisus
+    /// Get a temperature from the sensor in degrees celsius
     ///
     /// Returns Some(temperature) if available, otherwise returns
     /// None


### PR DESCRIPTION
This patch fixes a minor typo in `src/sensors/mod.rs`. `celsius` was spelled incorrectly in the comment.