### PR TITLE
Add Altimeter trait and default implementaiton

### DIFF
--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -37,8 +37,7 @@ pub trait Thermometer {
 
     /// Get a temperature from the sensor in degrees celsius
     ///
-    /// Returns Some(temperature) if available, otherwise returns
-    /// None
+    /// Returns `Ok(temperature)` if available, otherwise returns `Err(Self::Error)`
     fn temperature_celsius(&mut self) -> Result<f32, Self::Error>;
 }
 
@@ -48,8 +47,7 @@ pub trait Barometer {
 
     /// Get a pressure reading from the sensor in kPa
     ///
-    /// Returns Some(temperature) if avialable, otherwise returns
-    /// None
+    /// Returns `Ok(temperature)` if avialable, otherwise returns `Err(Self::Error)`
     fn pressure_kpa(&mut self) -> Result<f32, Self::Error>;
 }
 

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -52,3 +52,28 @@ pub trait Barometer {
     /// None
     fn pressure_kpa(&mut self) -> Result<f32, Self::Error>;
 }
+
+/// Trait for sensors that provide access to altitude readings
+pub trait Altimeter {
+    type Error: Error;
+
+    /// Get an altitude reading from the sensor in meters, relative to the pressure in kPa at
+    /// sea level
+    ///
+    /// Returns `Ok(altitude)` if available, otherwise returns `Err(Self::Error)`
+    fn altitude_meters(&mut self, sea_level_kpa: f32) -> Result<f32, Self::Error>;
+}
+
+impl<T> Altimeter for T
+    where T: Barometer
+{
+    type Error = <Self as Barometer>::Error;
+
+    fn altitude_meters(&mut self, sea_level_kpa: f32) -> Result<f32, Self::Error> {
+        let pressure = try!(self.pressure_kpa()) * 1000.;
+        let sea_level_pa = sea_level_kpa * 1000.;
+
+        let altitude = 44330. * (1. - (pressure / sea_level_pa).powf(0.1903));
+        Ok(altitude)
+    }
+}


### PR DESCRIPTION
This creates a trait for Altimeter sensors, providing altitude readings in meters. There is also a default implementation specified for any type that implements Barometer. I also fixed some documentation that implied some functions had different return types than what they really do.