### PR TITLE
Update dependencies to latest stable and fix fallout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,6 @@ os:
 - linux
 - osx
 
-env:
-  global:
-  - secure: gZdvTl4i1QfHQaCUPcVpnLtlrsE4WldSm99AD9C9jiMgjlzhhI4kQmIhssNFhA1BWDW6qDazrKnw4ZT1GA/rlmGSpLxs2lfBNTjPF0CJMVSTEQ1OaFcDGajziTTCSMh7jDml1/CFHuGSc+rS4bNv5wu0bj+pz3ZSRSuB7Vgoa0aRD8JQKc+phnIoXMCCfIh9vxlXWvO9mDMoR84/B35/gN/vWIi3+uuHgvvdKMK8qBbJ0ne25kOIA5CpXzJmOBFHCGblVQM4+AiTWvWtoXJjMcJXn9HZ2g3HWhrnixG07Ee1RrjUPo25tsxrBowHSGq9Bbo+jzmOmx03CRnCBHyXk6e12MXrfVFWRdmFaf7Sl/RBlz8Y2BRgktp8ihB6JQmjNuRptE4RdnWn6CU9liSQ5nzzGEl2ZtBrzN9GR3qyhq5W9e09v93MZfBr0svp/rtBoqDANfkpxvmWqtgO3fjN1fdf092sEcQfq3d7e6NaLSWKkI6V9wJnJ9UulPDAaqGVm8RrA9b0vJR6ouCf5ChZgYirz6LW5uPpMkf+cjESU9JxnX9xVB8tfPSoNrPKolRC/WRZ8gPbRmx0vF4wrDk8z9Fks5nHGwDsPdYe60Qe8m6ZclncCkpUzy2yAZWe/kiDaseOwNbSqEUZW80hLyHpuGi1IFpGBQfc8mYMPvqOHa8=
-
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc
-
-after_success: '[ $TRAVIS_OS_NAME == linux ] && [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ] &&
-  echo "<meta http-equiv=refresh content=0;url=i2cdev/index.html>" > target/doc/index.html
-  && sudo pip install ghp-import && ghp-import -n target/doc && git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-  gh-pages'
-
-notifications:
-  webhooks: http://rust-embedded-bot.herokuapp.com/travis
+- cargo build --verbose
+- cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "i2cdev"
 build = "build.rs"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-i2cdev"
@@ -15,14 +15,14 @@ https://www.kernel.org/doc/Documentation/i2c/dev-interface
 """
 
 [dependencies]
-libc = "^0.2.7"
-bitflags = "^0.5.0"
-byteorder = "^0.4.2"
-nix = "^0.6.0"
+libc = "0.2"
+bitflags = "1"
+byteorder = "1"
+nix = "0.10"
 
 [dev-dependencies]
-docopt = "^0.6.78"
-skeptic = "^0.5"
+docopt = "0.8"
+skeptic = "0.13"
 
 [build-dependencies]
-skeptic = "^0.5"
+skeptic = "0.13"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Rust I2cdev
 [![Version](https://img.shields.io/crates/v/i2cdev.svg)](https://crates.io/crates/i2cdev)
 [![License](https://img.shields.io/crates/l/i2cdev.svg)](https://github.com/rust-embedded/rust-i2cdev/blob/master/README.md#license)
 
-[Documentation](https://rust-embedded.github.io/rust-i2cdev)
+[Documentation](https://docs.rs/i2cdev)
 
 The Rust `i2cdev` crate seeks to provide full access to the Linux i2cdev
 driver interface in Rust without the need to wrap any C code or directly make
@@ -26,7 +26,7 @@ functions (read/write) which are done via the Read/Write traits (if
 you actually want to use the Wii Nunchuck you should use
 [`i2cdev::sensors::nunchuck::Nunchuck`][nunchuck]:
 
-```rust,no_run
+```rust,no_run,skeptic-template
 extern crate i2cdev;
 
 use std::thread;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -19,23 +19,23 @@ use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 pub type I2CError = nix::Error;
 
 bitflags! {
-    flags I2CMsgFlags: u16 {
+    struct I2CMsgFlags: u16 {
         /// this is a ten bit chip address
-        const I2C_M_TEN = 0x0010,
+        const I2C_M_TEN = 0x0010;
         /// read data, from slave to master
-        const I2C_M_RD = 0x0001,
+        const I2C_M_RD = 0x0001;
         /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_STOP = 0x8000,
+        const I2C_M_STOP = 0x8000;
         /// if I2C_FUNC_NOSTART
-        const I2C_M_NOSTART = 0x4000,
+        const I2C_M_NOSTART = 0x4000;
         /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_REV_DIR_ADDR = 0x2000,
+        const I2C_M_REV_DIR_ADDR = 0x2000;
         /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_IGNORE_NAK = 0x1000,
+        const I2C_M_IGNORE_NAK = 0x1000;
         /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_NO_RD_ACK = 0x0800,
+        const I2C_M_NO_RD_ACK = 0x0800;
         /// length will be first received byte
-        const I2C_M_RECV_LEN = 0x0400,
+        const I2C_M_RECV_LEN = 0x0400;
     }
 }
 
@@ -52,44 +52,44 @@ struct i2c_msg {
 }
 
 bitflags! {
-    flags I2CFunctions: u32 {
-        const I2C_FUNC_I2C = 0x00000001,
-        const I2C_FUNC_10BIT_ADDR = 0x00000002,
-        const I2C_FUNC_PROTOCOL_MANGLING = 0x00000004, /* I2C_M_IGNORE_NAK etc. */
-        const I2C_FUNC_SMBUS_PEC = 0x00000008,
-        const I2C_FUNC_NOSTART = 0x00000010, /* I2C_M_NOSTART */
-        const I2C_FUNC_SMBUS_BLOCK_PROC_CALL = 0x00008000, /* SMBus 2.0 */
-        const I2C_FUNC_SMBUS_QUICK = 0x00010000,
-        const I2C_FUNC_SMBUS_READ_BYTE = 0x00020000,
-        const I2C_FUNC_SMBUS_WRITE_BYTE = 0x00040000,
-        const I2C_FUNC_SMBUS_READ_BYTE_DATA = 0x00080000,
-        const I2C_FUNC_SMBUS_WRITE_BYTE_DATA = 0x00100000,
-        const I2C_FUNC_SMBUS_READ_WORD_DATA = 0x00200000,
-        const I2C_FUNC_SMBUS_WRITE_WORD_DATA = 0x00400000,
-        const I2C_FUNC_SMBUS_PROC_CALL = 0x00800000,
-        const I2C_FUNC_SMBUS_READ_BLOCK_DATA = 0x01000000,
-        const I2C_FUNC_SMBUS_WRITE_BLOCK_DATA  = 0x02000000,
-        const I2C_FUNC_SMBUS_READ_I2C_BLOCK = 0x04000000, /* I2C-like block xfer  */
-        const I2C_FUNC_SMBUS_WRITE_I2C_BLOCK = 0x08000000, /* w/ 1-byte reg. addr. */
+    struct I2CFunctions: u32 {
+        const I2C_FUNC_I2C = 0x00000001;
+        const I2C_FUNC_10BIT_ADDR = 0x00000002;
+        const I2C_FUNC_PROTOCOL_MANGLING = 0x00000004; /* I2C_M_IGNORE_NAK etc. */
+        const I2C_FUNC_SMBUS_PEC = 0x00000008;
+        const I2C_FUNC_NOSTART = 0x00000010; /* I2C_M_NOSTART */
+        const I2C_FUNC_SMBUS_BLOCK_PROC_CALL = 0x00008000; /* SMBus 2.0 */
+        const I2C_FUNC_SMBUS_QUICK = 0x00010000;
+        const I2C_FUNC_SMBUS_READ_BYTE = 0x00020000;
+        const I2C_FUNC_SMBUS_WRITE_BYTE = 0x00040000;
+        const I2C_FUNC_SMBUS_READ_BYTE_DATA = 0x00080000;
+        const I2C_FUNC_SMBUS_WRITE_BYTE_DATA = 0x00100000;
+        const I2C_FUNC_SMBUS_READ_WORD_DATA = 0x00200000;
+        const I2C_FUNC_SMBUS_WRITE_WORD_DATA = 0x00400000;
+        const I2C_FUNC_SMBUS_PROC_CALL = 0x00800000;
+        const I2C_FUNC_SMBUS_READ_BLOCK_DATA = 0x01000000;
+        const I2C_FUNC_SMBUS_WRITE_BLOCK_DATA  = 0x02000000;
+        const I2C_FUNC_SMBUS_READ_I2C_BLOCK = 0x04000000; /* I2C-like block xfer  */
+        const I2C_FUNC_SMBUS_WRITE_I2C_BLOCK = 0x08000000; /* w/ 1-byte reg. addr. */
 
-        const I2C_FUNC_SMBUS_BYTE = (I2C_FUNC_SMBUS_READ_BYTE.bits |
-                                     I2C_FUNC_SMBUS_WRITE_BYTE.bits),
-        const I2C_FUNC_SMBUS_BYTE_DATA = (I2C_FUNC_SMBUS_READ_BYTE_DATA.bits |
-                                          I2C_FUNC_SMBUS_WRITE_BYTE_DATA.bits),
-        const I2C_FUNC_SMBUS_WORD_DATA = (I2C_FUNC_SMBUS_READ_WORD_DATA.bits |
-                                          I2C_FUNC_SMBUS_WRITE_WORD_DATA.bits),
-        const I2C_FUNC_SMBUS_BLOCK_DATA = (I2C_FUNC_SMBUS_READ_BLOCK_DATA.bits |
-                                           I2C_FUNC_SMBUS_WRITE_BLOCK_DATA.bits),
-        const I2C_FUNC_SMBUS_I2C_BLOCK = (I2C_FUNC_SMBUS_READ_I2C_BLOCK.bits |
-                                          I2C_FUNC_SMBUS_WRITE_I2C_BLOCK.bits),
-        const I2C_FUNC_SMBUS_EMUL = (I2C_FUNC_SMBUS_QUICK.bits |
-                                     I2C_FUNC_SMBUS_BYTE.bits |
-                                     I2C_FUNC_SMBUS_BYTE_DATA.bits |
-                                     I2C_FUNC_SMBUS_WORD_DATA.bits |
-                                     I2C_FUNC_SMBUS_PROC_CALL.bits |
-                                     I2C_FUNC_SMBUS_WRITE_BLOCK_DATA.bits |
-                                     I2C_FUNC_SMBUS_I2C_BLOCK.bits |
-                                     I2C_FUNC_SMBUS_PEC.bits),
+        const I2C_FUNC_SMBUS_BYTE = (I2CFunctions::I2C_FUNC_SMBUS_READ_BYTE.bits |
+                                     I2CFunctions::I2C_FUNC_SMBUS_WRITE_BYTE.bits);
+        const I2C_FUNC_SMBUS_BYTE_DATA = (I2CFunctions::I2C_FUNC_SMBUS_READ_BYTE_DATA.bits |
+                                          I2CFunctions::I2C_FUNC_SMBUS_WRITE_BYTE_DATA.bits);
+        const I2C_FUNC_SMBUS_WORD_DATA = (I2CFunctions::I2C_FUNC_SMBUS_READ_WORD_DATA.bits |
+                                          I2CFunctions::I2C_FUNC_SMBUS_WRITE_WORD_DATA.bits);
+        const I2C_FUNC_SMBUS_BLOCK_DATA = (I2CFunctions::I2C_FUNC_SMBUS_READ_BLOCK_DATA.bits |
+                                           I2CFunctions::I2C_FUNC_SMBUS_WRITE_BLOCK_DATA.bits);
+        const I2C_FUNC_SMBUS_I2C_BLOCK = (I2CFunctions::I2C_FUNC_SMBUS_READ_I2C_BLOCK.bits |
+                                          I2CFunctions::I2C_FUNC_SMBUS_WRITE_I2C_BLOCK.bits);
+        const I2C_FUNC_SMBUS_EMUL = (I2CFunctions::I2C_FUNC_SMBUS_QUICK.bits |
+                                     I2CFunctions::I2C_FUNC_SMBUS_BYTE.bits |
+                                     I2CFunctions::I2C_FUNC_SMBUS_BYTE_DATA.bits |
+                                     I2CFunctions::I2C_FUNC_SMBUS_WORD_DATA.bits |
+                                     I2CFunctions::I2C_FUNC_SMBUS_PROC_CALL.bits |
+                                     I2CFunctions::I2C_FUNC_SMBUS_WRITE_BLOCK_DATA.bits |
+                                     I2CFunctions::I2C_FUNC_SMBUS_I2C_BLOCK.bits |
+                                     I2CFunctions::I2C_FUNC_SMBUS_PEC.bits);
     }
 }
 
@@ -151,7 +151,7 @@ const I2C_RDRW_IOCTL_MAX_MSGS: u8 = 42;
 
 /// This is the structure as used in the I2C_SMBUS ioctl call
 #[repr(C)]
-struct i2c_smbus_ioctl_data {
+pub struct i2c_smbus_ioctl_data {
     // __u8 read_write;
     read_write: u8,
     // __u8 command;
@@ -171,15 +171,12 @@ struct i2c_rdwr_ioctl_data {
     nmsgs: u32,
 }
 
-ioctl!(bad ioctl_set_i2c_slave_address with I2C_SLAVE);
-ioctl!(bad ioctl_i2c_smbus with I2C_SMBUS);
+ioctl!(bad write_int ioctl_set_i2c_slave_address with I2C_SLAVE);
+ioctl!(bad write_ptr ioctl_i2c_smbus with I2C_SMBUS; i2c_smbus_ioctl_data);
 
 pub fn i2c_set_slave_address(fd: RawFd, slave_address: u16) -> Result<(), nix::Error> {
     try!(unsafe {
-        // NOTE: the generated ioctl call expected as pointer to a u8 but
-        // we just want to provide the u8 directly, so we just cast to a pointer.
-        // This is correct behavior.
-        ioctl_set_i2c_slave_address(fd, slave_address as *mut u8)
+        ioctl_set_i2c_slave_address(fd, slave_address as i32)
     });
     Ok(())
 }
@@ -198,8 +195,7 @@ unsafe fn i2c_smbus_access(fd: RawFd,
     };
 
     // remove type information
-    let p_args: *mut u8 = mem::transmute(&mut args);
-    ioctl_i2c_smbus(fd, p_args).map(drop)
+    ioctl_i2c_smbus(fd, &mut args).map(drop)
 }
 
 #[inline]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -171,12 +171,18 @@ struct i2c_rdwr_ioctl_data {
     nmsgs: u32,
 }
 
-ioctl!(bad write_int ioctl_set_i2c_slave_address with I2C_SLAVE);
-ioctl!(bad write_ptr ioctl_i2c_smbus with I2C_SMBUS; i2c_smbus_ioctl_data);
+mod ioctl {
+    use super::{I2C_SLAVE, I2C_SMBUS};
+    pub use super::i2c_smbus_ioctl_data;
+
+    ioctl!(bad write_int set_i2c_slave_address with I2C_SLAVE);
+    ioctl!(bad write_ptr i2c_smbus with I2C_SMBUS; i2c_smbus_ioctl_data);
+}
+
 
 pub fn i2c_set_slave_address(fd: RawFd, slave_address: u16) -> Result<(), nix::Error> {
     try!(unsafe {
-        ioctl_set_i2c_slave_address(fd, slave_address as i32)
+        ioctl::set_i2c_slave_address(fd, slave_address as i32)
     });
     Ok(())
 }
@@ -195,7 +201,7 @@ unsafe fn i2c_smbus_access(fd: RawFd,
     };
 
     // remove type information
-    ioctl_i2c_smbus(fd, &mut args).map(drop)
+    ioctl::i2c_smbus(fd, &mut args).map(drop)
 }
 
 #[inline]

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -48,7 +48,7 @@ impl From<LinuxI2CError> for io::Error {
             LinuxI2CError::Nix(e) => {
                 match e {
                     nix::Error::Sys(e) => io::Error::from_raw_os_error(e as i32),
-                    nix::Error::InvalidPath => {
+                    e => {
                         io::Error::new(io::ErrorKind::InvalidInput, format!("{:?}", e))
                     }
                 }


### PR DESCRIPTION
Several dependencies had quite out of date and there are some nice
stabilizations and features (for nix ioctl) upstream.  Nothing here
should change the external API