### PR TITLE
Fix block methods

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -102,7 +102,12 @@ pub trait I2CDevice {
     /// Comm byte. The amount of data is specified in the Count byte.
     fn smbus_write_block_data(&mut self, register: u8, values: &[u8]) -> Result<(), Self::Error>;
 
+    /// Write a block of up to 32 bytes from a device
+    ///
+    /// Uses write_i2c_block_data instead write_block_data.
+    fn smbus_write_i2c_block_data(&mut self, register: u8, values: &[u8]) -> Result<(), Self::Error>;
+
     /// Select a register, send 1 to 31 bytes of data to it, and reads
     /// 1 to 31 bytes of data from it.
-    fn smbus_process_block(&mut self, register: u8, values: &[u8]) -> Result<(), Self::Error>;
+    fn smbus_process_block(&mut self, register: u8, values: &[u8]) -> Result<Vec<u8>, Self::Error>;
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -403,3 +403,29 @@ pub fn i2c_smbus_write_i2c_block_data(fd: RawFd,
     });
     Ok(())
 }
+
+#[inline]
+pub fn i2c_smbus_process_call_block(fd: RawFd, register: u8, values: &[u8]) -> Result<Vec<u8>, I2CError> {
+    let mut data = i2c_smbus_data::empty();
+    let len: usize = if values.len() > 32 {
+        32
+    } else {
+        values.len()
+    };
+    data.block[0] = len as u8;
+    for i in 1..(len + 1) {
+        data.block[i] = values[i - 1];
+    }
+    try!(unsafe {
+        i2c_smbus_access(fd,
+                         I2CSMBusReadWrite::I2C_SMBUS_WRITE,
+                         register,
+                         I2CSMBusSize::I2C_SMBUS_BLOCK_PROC_CALL,
+                         &mut data)
+    });
+
+    // create a vector from the data in the block starting at byte
+    // 1 and ending after count bytes after that
+    let count = data.block[0];
+    Ok((&data.block[1..(count + 1) as usize]).to_vec())
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -407,8 +407,8 @@ pub fn i2c_smbus_write_i2c_block_data(fd: RawFd,
 #[inline]
 pub fn i2c_smbus_process_call_block(fd: RawFd, register: u8, values: &[u8]) -> Result<Vec<u8>, I2CError> {
     let mut data = i2c_smbus_data::empty();
-    let len: usize = if values.len() > 32 {
-        32
+    let len: usize = if values.len() > 31 {
+        31
     } else {
         values.len()
     };

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -210,9 +210,14 @@ impl I2CDevice for LinuxI2CDevice {
         ffi::i2c_smbus_write_block_data(self.as_raw_fd(), register, values).map_err(From::from)
     }
 
+    /// Write a block of up to 32 bytes from a device via i2c_smbus_i2c_write_block_data
+    fn smbus_write_i2c_block_data(&mut self, register: u8, values: &[u8]) -> Result<(), LinuxI2CError> {
+        ffi::i2c_smbus_write_i2c_block_data(self.as_raw_fd(), register, values).map_err(From::from)
+    }
+
     /// Select a register, send 1 to 31 bytes of data to it, and reads
     /// 1 to 31 bytes of data from it.
-    fn smbus_process_block(&mut self, register: u8, values: &[u8]) -> Result<(), LinuxI2CError> {
-        ffi::i2c_smbus_write_i2c_block_data(self.as_raw_fd(), register, values).map_err(From::from)
+    fn smbus_process_block(&mut self, register: u8, values: &[u8]) -> Result<Vec<u8>, LinuxI2CError> {
+        ffi::i2c_smbus_process_call_block(self.as_raw_fd(), register, values).map_err(From::from)
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -88,11 +88,15 @@ impl I2CDevice for MockI2CDevice {
         unimplemented!()
     }
 
-    fn smbus_process_block(&mut self, _register: u8, _values: &[u8]) -> I2CResult<()> {
+    fn smbus_process_block(&mut self, _register: u8, _values: &[u8]) -> I2CResult<Vec<u8>> {
         unimplemented!()
     }
 
     fn smbus_read_i2c_block_data(&mut self, _register: u8, _len: u8) -> I2CResult<Vec<u8>> {
+        unimplemented!()
+    }
+
+    fn smbus_write_i2c_block_data(&mut self, _register: u8, _values: &[u8]) -> I2CResult<()> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
`process_block` and `write_i2c_block` were mixed up and sort of one was missing.

Fixes #38 

Major breaking change to the api that probably means a 0.4 release.