### PR TITLE
Move from `try!` to `?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ const NUNCHUCK_SLAVE_ADDR: u16 = 0x52;
 
 // real code should probably not use unwrap()
 fn i2cfun() -> Result<(), LinuxI2CError> {
-    let mut dev = try!(LinuxI2CDevice::new("/dev/i2c-1", NUNCHUCK_SLAVE_ADDR));
+    let mut dev = LinuxI2CDevice::new("/dev/i2c-1", NUNCHUCK_SLAVE_ADDR)?;
 
     // init sequence
-    try!(dev.smbus_write_byte_data(0xF0, 0x55));
-    try!(dev.smbus_write_byte_data(0xFB, 0x00));
+    dev.smbus_write_byte_data(0xF0, 0x55)?;
+    dev.smbus_write_byte_data(0xFB, 0x00)?;
     thread::sleep(Duration::from_millis(100));
 
     loop {

--- a/examples/nunchuck.rs
+++ b/examples/nunchuck.rs
@@ -107,7 +107,7 @@ mod nunchuck {
         /// the future.
         pub fn new(i2cdev: T) -> Result<Nunchuck<T>, T::Error> {
             let mut nunchuck = Nunchuck { i2cdev: i2cdev };
-            try!(nunchuck.init());
+            nunchuck.init()?;
             Ok(nunchuck)
         }
 
@@ -121,8 +121,8 @@ mod nunchuck {
             // These registers must be written; the documentation is a bit
             // lacking but it appears this is some kind of handshake to
             // perform unencrypted data tranfers
-            try!(self.i2cdev.smbus_write_byte_data(0xF0, 0x55));
-            try!(self.i2cdev.smbus_write_byte_data(0xFB, 0x00));
+            self.i2cdev.smbus_write_byte_data(0xF0, 0x55)?;
+            self.i2cdev.smbus_write_byte_data(0xFB, 0x00)?;
             Ok(())
         }
 
@@ -138,7 +138,7 @@ mod nunchuck {
 
             // now, read it!
             thread::sleep(Duration::from_millis(10));
-            try!(self.i2cdev.read(&mut buf).map_err(NunchuckError::Error));
+            self.i2cdev.read(&mut buf).map_err(NunchuckError::Error)?;
             NunchuckReading::from_data(&buf).ok_or(NunchuckError::ParseError)
         }
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -33,7 +33,7 @@ pub trait I2CDevice {
     /// the previous SMBus command.
     fn smbus_read_byte(&mut self) -> Result<u8, Self::Error> {
         let mut buf = [0_u8];
-        try!(self.read(&mut buf));
+        self.read(&mut buf)?;
         Ok(buf[0])
     }
 
@@ -49,7 +49,7 @@ pub trait I2CDevice {
     ///
     /// The register is specified through the Comm byte.
     fn smbus_read_byte_data(&mut self, register: u8) -> Result<u8, Self::Error> {
-        try!(self.smbus_write_byte(register));
+        self.smbus_write_byte(register)?;
         self.smbus_read_byte()
     }
 
@@ -63,8 +63,8 @@ pub trait I2CDevice {
     /// Read 2 bytes from a given register on a device (lsb first)
     fn smbus_read_word_data(&mut self, register: u8) -> Result<u16, Self::Error> {
         let mut buf: [u8; 2] = [0x00; 2];
-        try!(self.smbus_write_byte(register));
-        try!(self.read(&mut buf));
+        self.smbus_write_byte(register)?;
+        self.read(&mut buf)?;
         Ok(LittleEndian::read_u16(&buf))
     }
 
@@ -78,8 +78,8 @@ pub trait I2CDevice {
     /// Select a register, send 16 bits of data to it, and read 16 bits of data
     fn smbus_process_word(&mut self, register: u8, value: u16) -> Result<u16, Self::Error> {
         let mut buf: [u8; 2] = [0x00; 2];
-        try!(self.smbus_write_word_data(register, value));
-        try!(self.read(&mut buf));
+        self.smbus_write_word_data(register, value)?;
+        self.read(&mut buf)?;
         Ok(LittleEndian::read_u16(&buf))
     }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -181,9 +181,9 @@ mod ioctl {
 
 
 pub fn i2c_set_slave_address(fd: RawFd, slave_address: u16) -> Result<(), nix::Error> {
-    try!(unsafe {
-        ioctl::set_i2c_slave_address(fd, slave_address as i32)
-    });
+    unsafe {
+        ioctl::set_i2c_slave_address(fd, slave_address as i32)?;
+    }
     Ok(())
 }
 
@@ -222,13 +222,13 @@ pub fn i2c_smbus_write_quick(fd: RawFd, bit: bool) -> Result<(), I2CError> {
 #[inline]
 pub fn i2c_smbus_read_byte(fd: RawFd) -> Result<u8, I2CError> {
     let mut data = i2c_smbus_data::empty();
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_READ,
                          0,
                          I2CSMBusSize::I2C_SMBUS_BYTE,
-                         &mut data)
-    });
+                         &mut data)?
+    }
     Ok(data.block[0])
 }
 
@@ -246,13 +246,13 @@ pub fn i2c_smbus_write_byte(fd: RawFd, value: u8) -> Result<(), I2CError> {
 #[inline]
 pub fn i2c_smbus_read_byte_data(fd: RawFd, register: u8) -> Result<u8, I2CError> {
     let mut data = i2c_smbus_data::empty();
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_READ,
                          register,
                          I2CSMBusSize::I2C_SMBUS_BYTE_DATA,
-                         &mut data)
-    });
+                         &mut data)?;
+    }
     Ok(data.block[0])
 }
 
@@ -260,26 +260,26 @@ pub fn i2c_smbus_read_byte_data(fd: RawFd, register: u8) -> Result<u8, I2CError>
 pub fn i2c_smbus_write_byte_data(fd: RawFd, register: u8, value: u8) -> Result<(), I2CError> {
     let mut data = i2c_smbus_data::empty();
     data.block[0] = value;
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_WRITE,
                          register,
                          I2CSMBusSize::I2C_SMBUS_BYTE_DATA,
-                         &mut data)
-    });
+                         &mut data)?;
+    }
     Ok(())
 }
 
 #[inline]
 pub fn i2c_smbus_read_word_data(fd: RawFd, register: u8) -> Result<u16, I2CError> {
     let mut data = i2c_smbus_data::empty();
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_READ,
                          register,
                          I2CSMBusSize::I2C_SMBUS_WORD_DATA,
-                         &mut data)
-    });
+                         &mut data)?;
+    };
 
     Ok(Cursor::new(&data.block[..])
            .read_u16::<NativeEndian>()
@@ -294,13 +294,13 @@ pub fn i2c_smbus_write_word_data(fd: RawFd, register: u8, value: u16) -> Result<
         .write_u16::<NativeEndian>(value)
         .unwrap();
 
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_WRITE,
                          register,
                          I2CSMBusSize::I2C_SMBUS_WORD_DATA,
-                         &mut data)
-    });
+                         &mut data)?;
+    };
     Ok(())
 }
 
@@ -311,13 +311,13 @@ pub fn i2c_smbus_process_call(fd: RawFd, register: u8, value: u16) -> Result<u16
         .write_u16::<NativeEndian>(value)
         .unwrap();
 
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_WRITE,
                          register,
                          I2CSMBusSize::I2C_SMBUS_PROC_CALL,
-                         &mut data)
-    });
+                         &mut data)?;
+    }
     Ok(Cursor::new(&data.block[..])
            .read_u16::<NativeEndian>()
            .unwrap())
@@ -326,13 +326,13 @@ pub fn i2c_smbus_process_call(fd: RawFd, register: u8, value: u16) -> Result<u16
 #[inline]
 pub fn i2c_smbus_read_block_data(fd: RawFd, register: u8) -> Result<Vec<u8>, I2CError> {
     let mut data = i2c_smbus_data::empty();
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_READ,
                          register,
                          I2CSMBusSize::I2C_SMBUS_BLOCK_DATA,
-                         &mut data)
-    });
+                         &mut data)?;
+    }
 
     // create a vector from the data in the block starting at byte
     // 1 and ending after count bytes after that
@@ -343,13 +343,13 @@ pub fn i2c_smbus_read_block_data(fd: RawFd, register: u8) -> Result<Vec<u8>, I2C
 pub fn i2c_smbus_read_i2c_block_data(fd: RawFd, register: u8, len: u8) -> Result<Vec<u8>, I2CError> {
     let mut data = i2c_smbus_data::empty();
     data.block[0] = len;
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_READ,
                          register,
                          I2CSMBusSize::I2C_SMBUS_I2C_BLOCK_DATA,
-                         &mut data)
-    });
+                         &mut data)?;
+    }
 
     // create a vector from the data in the block starting at byte
     // 1 and ending after count bytes after that
@@ -369,13 +369,13 @@ pub fn i2c_smbus_write_block_data(fd: RawFd, register: u8, values: &[u8]) -> Res
     for i in 1..(len + 1) {
         data.block[i] = values[i - 1];
     }
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_WRITE,
                          register,
                          I2CSMBusSize::I2C_SMBUS_BLOCK_DATA,
-                         &mut data)
-    });
+                         &mut data)?;
+    }
     Ok(())
 }
 
@@ -394,13 +394,13 @@ pub fn i2c_smbus_write_i2c_block_data(fd: RawFd,
     for i in 1..(len + 1) {
         data.block[i] = values[i - 1];
     }
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_WRITE,
                          register,
                          I2CSMBusSize::I2C_SMBUS_I2C_BLOCK_DATA,
-                         &mut data)
-    });
+                         &mut data)?;
+    }
     Ok(())
 }
 
@@ -416,13 +416,13 @@ pub fn i2c_smbus_process_call_block(fd: RawFd, register: u8, values: &[u8]) -> R
     for i in 1..(len + 1) {
         data.block[i] = values[i - 1];
     }
-    try!(unsafe {
+    unsafe {
         i2c_smbus_access(fd,
                          I2CSMBusReadWrite::I2C_SMBUS_WRITE,
                          register,
                          I2CSMBusSize::I2C_SMBUS_BLOCK_PROC_CALL,
-                         &mut data)
-    });
+                         &mut data)?;
+    };
 
     // create a vector from the data in the block starting at byte
     // 1 and ending after count bytes after that

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -93,15 +93,15 @@ impl LinuxI2CDevice {
     pub fn new<P: AsRef<Path>>(path: P,
                                slave_address: u16)
                                -> Result<LinuxI2CDevice, LinuxI2CError> {
-        let file = try!(OpenOptions::new()
+        let file = OpenOptions::new()
                             .read(true)
                             .write(true)
-                            .open(path));
+                            .open(path)?;
         let mut device = LinuxI2CDevice {
             devfile: file,
             slave_address: 0, // will be set later
         };
-        try!(device.set_slave_address(slave_address));
+        device.set_slave_address(slave_address)?;
         Ok(device)
     }
 
@@ -117,7 +117,7 @@ impl LinuxI2CDevice {
     /// necessary if you need to change the slave device and you do
     /// not want to create a new device.
     pub fn set_slave_address(&mut self, slave_address: u16) -> Result<(), LinuxI2CError> {
-        try!(ffi::i2c_set_slave_address(self.as_raw_fd(), slave_address));
+        ffi::i2c_set_slave_address(self.as_raw_fd(), slave_address)?;
         self.slave_address = slave_address;
         Ok(())
     }


### PR DESCRIPTION
The `?` operator has been around since [November 10, 2016](https://blog.rust-lang.org/2016/11/10/Rust-1.13.html) so I've refreshed the code to use it. This more for an exercise in working with the code base than anything else, so feel free to reject it.

This will affect folks on versions older than 1.13, which are few but as of the [2017 survey](https://blog.rust-lang.org/2017/09/05/Rust-2017-Survey-Results.html) there were 40 out of 5,368.

Currently waiting for it to build and run on my NTC Chip to test. I'll remove [WIP] when it's ready to roll.