### PR TITLE
Upgrade nix to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ https://www.kernel.org/doc/Documentation/i2c/dev-interface
 libc = "0.2"
 bitflags = "1"
 byteorder = "1"
-nix = "0.10"
+nix = "0.11"
 
 [dev-dependencies]
 docopt = "0.8"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -175,8 +175,8 @@ mod ioctl {
     use super::{I2C_SLAVE, I2C_SMBUS};
     pub use super::i2c_smbus_ioctl_data;
 
-    ioctl!(bad write_int set_i2c_slave_address with I2C_SLAVE);
-    ioctl!(bad write_ptr i2c_smbus with I2C_SMBUS; i2c_smbus_ioctl_data);
+    ioctl_write_int_bad!(set_i2c_slave_address, I2C_SLAVE);
+    ioctl_write_ptr_bad!(i2c_smbus, I2C_SMBUS, i2c_smbus_ioctl_data);
 }
 
 


### PR DESCRIPTION
The `nix` crate changed its interface in 0.11 and now requires using much more sane looking macros.