### PR TITLE
[WIP] Allow sending multiple read/write operations in one transfer 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ https://www.kernel.org/doc/Documentation/i2c/dev-interface
 libc = "0.2"
 bitflags = "1"
 byteorder = "1"
-nix = "0.10"
+nix = "0.11"
 
 [dev-dependencies]
 docopt = "0.8"

--- a/src/core.rs
+++ b/src/core.rs
@@ -119,12 +119,14 @@ pub trait I2CDevice {
 
 /// Messages sent to / from an I2C device as a batch
 pub trait I2CMessage {
+    type Flags;
+
     /// Represents a read operation
-    fn read(data: &[u8]) -> Self;
+    fn read(&self, data: &[u8]) -> Self;
 
     /// Represents a write operation
     fn write(&self, data: &[u8]) -> Self;
 
     /// Represents a custom operation or special opperands
-    fn custom(&self, data: &[u8], address: u16, flags: u16) -> Self;
+    fn custom(&self, data: &[u8], address: u16, flags: Self::Flags) -> Self;
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -16,6 +16,7 @@ use std::error::Error;
 /// Linux i2cdev interface.
 pub trait I2CDevice {
     type Error: Error;
+    type I2CMessage;
 
     /// Read data from the device to fill the provided slice
     fn read(&mut self, data: &mut [u8]) -> Result<(), Self::Error>;
@@ -113,7 +114,7 @@ pub trait I2CDevice {
     
     /// Send a batch of messages. Useful for when multiple buffers need to be
     /// sent or recieved without an I2C `stop` flag.
-    fn transfer<M: I2CMessage>(&self, messages: &[M]) -> Result<(), Self::Error>;
+    fn transfer(&self, messages: &[Self::I2CMessage]) -> Result<(), Self::Error>;
 }
 
 /// Messages sent to / from an I2C device as a batch

--- a/src/core.rs
+++ b/src/core.rs
@@ -110,4 +110,20 @@ pub trait I2CDevice {
     /// Select a register, send 1 to 31 bytes of data to it, and reads
     /// 1 to 31 bytes of data from it.
     fn smbus_process_block(&mut self, register: u8, values: &[u8]) -> Result<Vec<u8>, Self::Error>;
+    
+    /// Send a batch of messages. Useful for when multiple buffers need to be
+    /// sent or recieved without an I2C `stop` flag.
+    fn transfer<M: I2CMessage>(&self, messages: &[M]) -> Result<(), Self::Error>;
+}
+
+/// Messages sent to / from an I2C device as a batch
+pub trait I2CMessage {
+    /// Represents a read operation
+    fn read(data: &[u8]) -> Self;
+
+    /// Represents a write operation
+    fn write(&self, data: &[u8]) -> Self;
+
+    /// Represents a custom operation or special opperands
+    fn custom(&self, data: &[u8], address: u16, flags: u16) -> Self;
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -175,8 +175,8 @@ mod ioctl {
     use super::{I2C_SLAVE, I2C_SMBUS};
     pub use super::i2c_smbus_ioctl_data;
 
-    ioctl!(bad write_int set_i2c_slave_address with I2C_SLAVE);
-    ioctl!(bad write_ptr i2c_smbus with I2C_SMBUS; i2c_smbus_ioctl_data);
+    ioctl_write_int_bad!(set_i2c_slave_address, I2C_SLAVE);
+    ioctl_write_ptr_bad!(i2c_smbus, I2C_SMBUS, i2c_smbus_ioctl_data);
 }
 
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -18,37 +18,16 @@ use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 
 pub type I2CError = nix::Error;
 
-bitflags! {
-    struct I2CMsgFlags: u16 {
-        /// this is a ten bit chip address
-        const I2C_M_TEN = 0x0010;
-        /// read data, from slave to master
-        const I2C_M_RD = 0x0001;
-        /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_STOP = 0x8000;
-        /// if I2C_FUNC_NOSTART
-        const I2C_M_NOSTART = 0x4000;
-        /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_REV_DIR_ADDR = 0x2000;
-        /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_IGNORE_NAK = 0x1000;
-        /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_NO_RD_ACK = 0x0800;
-        /// length will be first received byte
-        const I2C_M_RECV_LEN = 0x0400;
-    }
-}
-
 #[repr(C)]
 pub struct i2c_msg {
     /// slave address
-    addr: u16,
+    pub(crate) addr: u16,
     /// serialized I2CMsgFlags
-    flags: u16,
+    pub(crate) flags: u16,
     /// msg length
-    len: u16,
+    pub(crate) len: u16,
     /// pointer to msg data
-    buf: *mut u8,
+    pub(crate) buf: *const u8,
 }
 
 bitflags! {

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -7,7 +7,10 @@
 // except according to those terms.
 
 use ffi;
-use core::I2CDevice;
+use core::{
+    I2CDevice,
+    I2CMessage
+};
 use std::error::Error;
 use std::path::Path;
 use std::fs::File;
@@ -219,5 +222,25 @@ impl I2CDevice for LinuxI2CDevice {
     /// 1 to 31 bytes of data from it.
     fn smbus_process_block(&mut self, register: u8, values: &[u8]) -> Result<Vec<u8>, LinuxI2CError> {
         ffi::i2c_smbus_process_call_block(self.as_raw_fd(), register, values).map_err(From::from)
+    }
+
+    fn transfer<LinuxMessage>(&self, messages: &[LinuxMessage]) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+}
+
+struct LinuxMessage;
+
+impl I2CMessage for LinuxMessage {
+    fn read(data: &[u8]) -> Self {
+        unimplemented!();
+    }
+
+    fn write(&self, data: &[u8]) -> Self {
+        unimplemented!();
+    }
+
+    fn custom(&self, data: &[u8], address: u16, flags: u16) -> Self {
+        unimplemented!();
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -9,7 +9,7 @@
 use ffi;
 use core::{
     I2CDevice,
-    I2CMessage
+    I2CMessage,
 };
 use std::error::Error;
 use std::path::Path;
@@ -128,6 +128,7 @@ impl LinuxI2CDevice {
 
 impl I2CDevice for LinuxI2CDevice {
     type Error = LinuxI2CError;
+    type I2CMessage = LinuxMessage;
 
     /// Read data from the device to fill the provided slice
     fn read(&mut self, data: &mut [u8]) -> Result<(), LinuxI2CError> {
@@ -224,12 +225,12 @@ impl I2CDevice for LinuxI2CDevice {
         ffi::i2c_smbus_process_call_block(self.as_raw_fd(), register, values).map_err(From::from)
     }
 
-    fn transfer<LinuxMessage>(&self, messages: &[LinuxMessage]) -> Result<(), Self::Error> {
-        unimplemented!()
+    fn transfer(&self, messages: &[LinuxMessage]) -> Result<(), LinuxI2CError> {
+        ffi::i2c_rdwr(self.as_raw_fd(), messages).map_err(From::from)
     }
 }
 
-struct LinuxMessage;
+type LinuxMessage = ffi::i2c_msg;
 
 impl I2CMessage for LinuxMessage {
     fn read(data: &[u8]) -> Self {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -5,7 +5,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
-use core::I2CDevice;
+use core::{
+    I2CDevice,
+    I2CMessage,
+};
 use std::io;
 
 pub type I2CResult<T> = io::Result<T>;
@@ -54,6 +57,22 @@ impl I2CRegisterMap {
     }
 }
 
+struct MockMessage;
+
+impl I2CMessage for MockMessage {
+    fn read(data: &[u8]) -> Self {
+        unimplemented!();
+    }
+
+    fn write(&self, data: &[u8]) -> Self {
+        unimplemented!();
+    }
+
+    fn custom(&self, data: &[u8], address: u16, flags: u16) -> Self {
+        unimplemented!();
+    }
+}
+
 pub struct MockI2CDevice {
     pub regmap: I2CRegisterMap,
 }
@@ -97,6 +116,10 @@ impl I2CDevice for MockI2CDevice {
     }
 
     fn smbus_write_i2c_block_data(&mut self, _register: u8, _values: &[u8]) -> I2CResult<()> {
+        unimplemented!()
+    }
+
+    fn transfer<MockMessage>(&self, messages: &[MockMessage]) -> Result<(), Self::Error> {
         unimplemented!()
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -60,15 +60,17 @@ impl I2CRegisterMap {
 pub struct MockMessage;
 
 impl I2CMessage for MockMessage {
-    fn read(data: &[u8]) -> Self {
+    type Flags = ();
+
+    fn read(&self, _data: &[u8]) -> Self {
         unimplemented!();
     }
 
-    fn write(&self, data: &[u8]) -> Self {
+    fn write(&self, _data: &[u8]) -> Self {
         unimplemented!();
     }
 
-    fn custom(&self, data: &[u8], address: u16, flags: u16) -> Self {
+    fn custom(&self, _data: &[u8], _address: u16, _flags: ()) -> Self {
         unimplemented!();
     }
 }
@@ -120,7 +122,7 @@ impl I2CDevice for MockI2CDevice {
         unimplemented!()
     }
 
-    fn transfer(&self, messages: &[MockMessage]) -> Result<(), Self::Error> {
+    fn transfer(&self, _messages: &[MockMessage]) -> Result<(), Self::Error> {
         unimplemented!()
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -57,7 +57,7 @@ impl I2CRegisterMap {
     }
 }
 
-struct MockMessage;
+pub struct MockMessage;
 
 impl I2CMessage for MockMessage {
     fn read(data: &[u8]) -> Self {
@@ -86,6 +86,7 @@ impl MockI2CDevice {
 
 impl I2CDevice for MockI2CDevice {
     type Error = io::Error;
+    type I2CMessage = MockMessage;
 
     fn read(&mut self, data: &mut [u8]) -> I2CResult<()> {
         self.regmap.read(data)
@@ -119,7 +120,7 @@ impl I2CDevice for MockI2CDevice {
         unimplemented!()
     }
 
-    fn transfer<MockMessage>(&self, messages: &[MockMessage]) -> Result<(), Self::Error> {
+    fn transfer(&self, messages: &[MockMessage]) -> Result<(), Self::Error> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
I've started mocking up what *I* think the interface for the I2C_RDWR should look like, and I'm too green to be confident this is a good plan. While this compiles alright, Traits are also one of those things I'm not overly comfortable with.

The two things I think I want to change are:
1. The 'flags' u16 parameter on the 'custom' function should be a trait as well
2. Should there be some sort of factory class? Maybe that can be left up to the implementer?