### PR TITLE
bump nix to 0.14 to fix libc issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "i2cdev"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-i2cdev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ https://www.kernel.org/doc/Documentation/i2c/dev-interface
 libc = "0.2"
 bitflags = "1"
 byteorder = "1"
-nix = "0.11"
+nix = "0.14"
 
 [dev-dependencies]
 docopt = "0.8"


### PR DESCRIPTION
~Waiting on: https://github.com/nix-rust/nix/issues/1060#issuecomment-494627579~
See also: https://github.com/rust-embedded/linux-embedded-hal/pull/17
Patching up to git source tested to be working