### PR TITLE
Transactional read/write via I2C_RDWR ioctl - take 2

### DIFF
--- a/examples/pca9956b.rs
+++ b/examples/pca9956b.rs
@@ -1,0 +1,83 @@
+// Copyright 2018, Piers Finlayson <piers@piersandkatie.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.extern crate i2cdev;
+
+extern crate i2cdev;
+extern crate docopt;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use i2cdev::linux::{LinuxI2CBus, I2CMsg};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use i2cdev::core::I2CBus;
+
+use std::env::args;
+use docopt::Docopt;
+
+const USAGE: &str = "
+Reads registers from a PCA9956B IC via Linux i2cdev.
+
+Assumes the PCA9956B is using address 0x20.
+
+Usage:
+  pca9956b <device>
+  pca9956b (-h | --help)
+  pca9956b --version
+
+Options:
+  -h --help    Show this help text.
+  --version    Show version.
+";
+
+const ADDR: u16 = 0x20;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn main() {
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.argv(args()).parse())
+        .unwrap_or_else(|e| e.exit());
+    let path = args.get_str("<device>");
+    let mut bus = match LinuxI2CBus::new(path) {
+        Ok(bus) => bus,
+        Err(_e) => {
+            println!("Error opening I2C Bus {} {}", path, _e);
+            return
+        }
+    };
+    println!("Opened I2C Bus OK: {}", path);
+
+    // Build two I2C messages:
+    // 1) Write the MODE1 register address, with top bit indcating auto-
+    //    increment should be enabled
+    // 2) Read 10 bytes from the current register onwards
+    let mut dataw: Vec<u8> = vec![0b1000_0000]; 
+    let mut data: Vec<u8> = vec![0; 10]; 
+    let mut msgs: Vec<I2CMsg> = Vec::new();
+    msgs.push(I2CMsg::new(ADDR, &mut dataw));
+    msgs.push(I2CMsg::new(ADDR, &mut data));
+    msgs[1].set_read();
+
+    // Send the messages to the kernel to process
+    match bus.rdwr(&mut msgs) {
+        Ok(rc) => {
+            println!("Successful RDWR call: {} messages processed", rc)
+        },
+        Err(_e) => {
+            println!("Error reading/writing {}", _e);
+            return
+        },
+    }
+
+    // Print the data read from the device.  A recently reset PCA9956B should
+    // return:
+    // 0x8005000000000000ff00
+    let mut output = "Result: 0x".to_string();
+    let data = msgs[1].data();
+    for byte in data {
+        output = format!("{}{:02x}", output, byte);
+    }
+    println!("{}", output);
+}

--- a/examples/pca9956b.rs
+++ b/examples/pca9956b.rs
@@ -10,7 +10,7 @@ extern crate i2cdev;
 extern crate docopt;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use i2cdev::core::{I2CBus, I2CMessage};
+use i2cdev::core::{I2CTransfer, I2CMessage};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use i2cdev::linux::{LinuxI2CBus, LinuxI2CMessage};
 

--- a/examples/pca9956b.rs
+++ b/examples/pca9956b.rs
@@ -55,8 +55,8 @@ fn main() {
     // 2) Read 10 bytes from the current register onwards
     let mut data = [0; 10];
     let mut msgs = [
-        LinuxI2CMessage::write(ADDR, &[0b1000_0000]),
-        LinuxI2CMessage::read(ADDR, &mut data),
+        LinuxI2CMessage::write(&[0b1000_0000]).with_address(ADDR),
+        LinuxI2CMessage::read(&mut data).with_address(ADDR),
     ];
 
     // Send the messages to the kernel to process

--- a/src/core.rs
+++ b/src/core.rs
@@ -123,21 +123,21 @@ pub trait I2CDevice {
 ///
 /// Typical implementations will store state with references to the bus
 /// in use.  The trait is based on the Linux i2cdev interface.
-pub trait I2CBus {
+pub trait I2CBus<'a> {
     type Error: Error;
-    type Message: I2CMessage;
+    type Message: I2CMessage<'a>;
 
     // Performs multiple serially chained I2C read/write transactions.  On
     // success the return code is the number of successfully executed
     // transactions
-    fn transfer(&mut self, msgs: &mut [Self::Message]) -> Result<u32, Self::Error>;
+    fn transfer(&mut self, msgs: &'a mut [Self::Message]) -> Result<u32, Self::Error>;
 }
 
 /// Read/Write I2C message
-pub trait I2CMessage {
+pub trait I2CMessage<'a> {
     /// Read data from device
-    fn read(slave_address: u16, data: &mut [u8]) -> Self;
+    fn read(slave_address: u16, data: &'a mut [u8]) -> Self;
 
     /// Write data to device
-    fn write(slave_address: u16, data: &[u8]) -> Self;
+    fn write(slave_address: u16, data: &'a [u8]) -> Self;
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -136,8 +136,8 @@ pub trait I2CTransfer<'a> {
 /// Read/Write I2C message
 pub trait I2CMessage<'a> {
     /// Read data from device
-    fn read(slave_address: u16, data: &'a mut [u8]) -> Self;
+    fn read(data: &'a mut [u8]) -> Self;
 
     /// Write data to device
-    fn write(slave_address: u16, data: &'a [u8]) -> Self;
+    fn write(data: &'a [u8]) -> Self;
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -123,7 +123,7 @@ pub trait I2CDevice {
 ///
 /// Typical implementations will store state with references to the bus
 /// in use.  The trait is based on the Linux i2cdev interface.
-pub trait I2CBus<'a> {
+pub trait I2CTransfer<'a> {
     type Error: Error;
     type Message: I2CMessage<'a>;
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,33 +14,18 @@ use std::mem;
 use std::ptr;
 use std::io::Cursor;
 use std::os::unix::prelude::*;
+use std::marker::PhantomData;
 use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
+use core::{I2CMsg};
+use libc::c_int;
 
 pub type I2CError = nix::Error;
 
-bitflags! {
-    struct I2CMsgFlags: u16 {
-        /// this is a ten bit chip address
-        const I2C_M_TEN = 0x0010;
-        /// read data, from slave to master
-        const I2C_M_RD = 0x0001;
-        /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_STOP = 0x8000;
-        /// if I2C_FUNC_NOSTART
-        const I2C_M_NOSTART = 0x4000;
-        /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_REV_DIR_ADDR = 0x2000;
-        /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_IGNORE_NAK = 0x1000;
-        /// if I2C_FUNC_PROTOCOL_MANGLING
-        const I2C_M_NO_RD_ACK = 0x0800;
-        /// length will be first received byte
-        const I2C_M_RECV_LEN = 0x0400;
-    }
-}
-
 #[repr(C)]
-struct i2c_msg {
+#[derive(Debug)]
+/// C version of i2c_msg structure
+// See linux/i2c.h
+struct i2c_msg<'a> {
     /// slave address
     addr: u16,
     /// serialized I2CMsgFlags
@@ -49,6 +34,19 @@ struct i2c_msg {
     len: u16,
     /// pointer to msg data
     buf: *mut u8,
+    _phantom: PhantomData<&'a mut u8>,
+}
+
+impl<'a, 'b> From<&'b mut I2CMsg<'a>> for i2c_msg<'a> {
+    fn from(msg: &mut I2CMsg) -> Self {
+        i2c_msg {
+            addr: msg.addr,
+            flags: msg.flags,
+            len: msg.data.len() as u16,
+            buf: msg.data.as_mut_ptr(),
+            _phantom: PhantomData
+        }
+    }
 }
 
 bitflags! {
@@ -163,22 +161,24 @@ pub struct i2c_smbus_ioctl_data {
 }
 
 /// This is the structure as used in the I2C_RDWR ioctl call
+// see linux/i2c-dev.h
 #[repr(C)]
-struct i2c_rdwr_ioctl_data {
+pub struct i2c_rdwr_ioctl_data<'a> {
     // struct i2c_msg __user *msgs;
-    msgs: *mut i2c_msg,
+    msgs: *mut i2c_msg<'a>,
     // __u32 nmsgs;
     nmsgs: u32,
 }
 
 mod ioctl {
-    use super::{I2C_SLAVE, I2C_SMBUS};
+    use super::{I2C_SLAVE, I2C_SMBUS, I2C_RDWR};
     pub use super::i2c_smbus_ioctl_data;
+    pub use super::i2c_rdwr_ioctl_data;
 
     ioctl_write_int_bad!(set_i2c_slave_address, I2C_SLAVE);
     ioctl_write_ptr_bad!(i2c_smbus, I2C_SMBUS, i2c_smbus_ioctl_data);
+    ioctl_write_ptr_bad!(i2c_rdwr, I2C_RDWR, i2c_rdwr_ioctl_data);
 }
-
 
 pub fn i2c_set_slave_address(fd: RawFd, slave_address: u16) -> Result<(), nix::Error> {
     unsafe {
@@ -429,3 +429,31 @@ pub fn i2c_smbus_process_call_block(fd: RawFd, register: u8, values: &[u8]) -> R
     let count = data.block[0];
     Ok((&data.block[1..(count + 1) as usize]).to_vec())
 }
+
+// Returns the number of messages succesfully processed
+unsafe fn i2c_rdwr_access(fd: RawFd,
+                          msgs: *mut i2c_msg,
+                          nmsgs: usize)
+                          -> Result<(c_int), I2CError> {
+    let args = i2c_rdwr_ioctl_data {
+        msgs,
+        nmsgs: nmsgs as u32,
+    };
+
+    ioctl::i2c_rdwr(fd, &args)
+}
+
+pub fn i2c_rdwr_read_write(fd: RawFd,
+                           msgs: &mut Vec<I2CMsg>) -> Result<(i32), I2CError> {
+    // Building the msgs to push is safe.
+    // We have to use iter_mut as buf needs to be mutable.
+    let mut cmsgs = msgs.iter_mut().map(<i2c_msg>::from).collect::<Vec<_>>();
+
+    // But calling the ioctl is definitely not!
+    unsafe {
+        i2c_rdwr_access(fd,
+                        cmsgs.as_mut_ptr(),
+                        cmsgs.len())
+    }
+}
+

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -30,7 +30,7 @@ pub struct i2c_msg {
     pub(crate) len: u16,
     /// pointer to msg data
     pub(crate) buf: *const u8,
-        }
+}
 
 bitflags! {
     struct I2CFunctions: u32 {
@@ -420,8 +420,9 @@ pub fn i2c_rdwr(fd: RawFd, values: &mut [i2c_msg]) -> Result<u32, I2CError> {
         nmsgs: values.len() as u32,
     };
 
+    let n;
     unsafe {
-        let n = ioctl::i2c_rdwr(fd, &i2c_data)?;
-        Ok(n as u32)
+        n = ioctl::i2c_rdwr(fd, &i2c_data)?;
     }
+    Ok(n as u32)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,33 @@
 //!     }
 //! }
 //! ```
+//! 
+//! ```rust,no_run
+//! extern crate i2cdev;
+//!
+//! use std::thread;
+//! use std::time::Duration;
+//!
+//! use i2cdev::core::*;
+//! use i2cdev::linux::{LinuxI2CBus, LinuxI2CError, LinuxI2CMessage};
+//!
+//! const SLAVE_ADDR: u16 = 0x57;
+//!
+//! fn write_read_transaction() -> Result<(), LinuxI2CError> {
+//!     let mut dev = LinuxI2CBus::new("/dev/i2c-1")?;
+//!
+//!     let mut read_data = [0; 2];
+//!     let mut msgs = [
+//!         LinuxI2CMessage::write(SLAVE_ADDR, &[0x01]),
+//!         LinuxI2CMessage::read(SLAVE_ADDR, &mut read_data)
+//!     ];
+//!     dev.transfer(&mut msgs)?;
+//!     thread::sleep(Duration::from_millis(100));
+//!
+//!     println!("Reading: {:?}", read_data);
+//!     Ok(())
+//! }
+//! ```
 
 #![crate_name = "i2cdev"]
 #![crate_type = "lib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! https://www.kernel.org/doc/Documentation/i2c/dev-interface
 //! ```rust,no_run
 //! extern crate i2cdev;
-//! 
+//!
 //! use std::thread;
 //! use std::time::Duration;
 //!
@@ -22,7 +22,7 @@
 //! use i2cdev::linux::{LinuxI2CDevice, LinuxI2CError};
 //!
 //! const NUNCHUCK_SLAVE_ADDR: u16 = 0x52;
-//! 
+//!
 //! // real code should probably not use unwrap()
 //! fn i2cfun() -> Result<(), LinuxI2CError> {
 //!     let mut dev = LinuxI2CDevice::new("/dev/i2c-1", NUNCHUCK_SLAVE_ADDR)?;
@@ -41,7 +41,33 @@
 //!     }
 //! }
 //! ```
-//! 
+//!
+//! ```rust,no_run
+//! extern crate i2cdev;
+//!
+//! use std::thread;
+//! use std::time::Duration;
+//!
+//! use i2cdev::core::*;
+//! use i2cdev::linux::{LinuxI2CDevice, LinuxI2CError, LinuxI2CMessage};
+//!
+//! const SLAVE_ADDR: u16 = 0x57;
+//!
+//! fn write_read_transaction() -> Result<(), LinuxI2CError> {
+//!     let mut dev = LinuxI2CDevice::new("/dev/i2c-1", SLAVE_ADDR)?;
+//!
+//!     let mut read_data = [0; 2];
+//!     let mut msgs = [
+//!         LinuxI2CMessage::write(&[0x01]),
+//!         LinuxI2CMessage::read(&mut read_data)
+//!     ];
+//!     dev.transfer(&mut msgs)?;
+//!
+//!     println!("Reading: {:?}", read_data);
+//!     Ok(())
+//! }
+//! ```
+//!
 //! ```rust,no_run
 //! extern crate i2cdev;
 //!
@@ -53,16 +79,15 @@
 //!
 //! const SLAVE_ADDR: u16 = 0x57;
 //!
-//! fn write_read_transaction() -> Result<(), LinuxI2CError> {
+//! fn write_read_transaction_using_bus() -> Result<(), LinuxI2CError> {
 //!     let mut dev = LinuxI2CBus::new("/dev/i2c-1")?;
 //!
 //!     let mut read_data = [0; 2];
 //!     let mut msgs = [
-//!         LinuxI2CMessage::write(SLAVE_ADDR, &[0x01]),
-//!         LinuxI2CMessage::read(SLAVE_ADDR, &mut read_data)
+//!         LinuxI2CMessage::write(&[0x01]).with_address(SLAVE_ADDR),
+//!         LinuxI2CMessage::read(&mut read_data).with_address(SLAVE_ADDR)
 //!     ];
 //!     dev.transfer(&mut msgs)?;
-//!     thread::sleep(Duration::from_millis(100));
 //!
 //!     println!("Reading: {:?}", read_data);
 //!     Ok(())

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -251,14 +251,14 @@ impl LinuxI2CBus {
 }
 
 /// Linux I2C message
-pub type LinuxI2CMessage = ffi::i2c_msg;
+pub type LinuxI2CMessage<'a> = ffi::i2c_msg;
 
-impl I2CBus for LinuxI2CBus {
+impl<'a> I2CBus<'a> for LinuxI2CBus {
     type Error = LinuxI2CError;
-    type Message = LinuxI2CMessage;
+    type Message = LinuxI2CMessage<'a>;
 
     /// Issue the provided sequence of I2C transactions
-    fn transfer(&mut self, msgs: &mut [Self::Message]) -> Result<u32, LinuxI2CError> {
+    fn transfer(&mut self, msgs: &'a mut [Self::Message]) -> Result<u32, LinuxI2CError> {
         ffi::i2c_rdwr(self.as_raw_fd(), msgs).map_err(From::from)
     }
 }
@@ -288,8 +288,8 @@ bitflags! {
     }
 }
 
-impl I2CMessage for LinuxI2CMessage {
-    fn read(slave_address: u16, data: &mut [u8]) -> LinuxI2CMessage {
+impl<'a> I2CMessage<'a> for LinuxI2CMessage<'a> {
+    fn read(slave_address: u16, data: &'a mut [u8]) -> LinuxI2CMessage {
         Self {
             addr: slave_address,
             flags: I2CMessageFlags::READ.bits(),
@@ -298,7 +298,7 @@ impl I2CMessage for LinuxI2CMessage {
         }
     }
 
-    fn write(slave_address: u16, data: &[u8]) -> LinuxI2CMessage {
+    fn write(slave_address: u16, data: &'a [u8]) -> LinuxI2CMessage {
         Self {
             addr: slave_address,
             flags: I2CMessageFlags::empty().bits(),
@@ -308,7 +308,7 @@ impl I2CMessage for LinuxI2CMessage {
     }
 }
 
-impl LinuxI2CMessage {
+impl<'a> LinuxI2CMessage<'a> {
     pub fn with_flags(self, flags: I2CMessageFlags) -> Self {
         Self {
             addr: self.addr,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use ffi;
-use core::{I2CDevice, I2CBus};
+use core::{I2CDevice, I2CTransfer};
 use std::error::Error;
 use std::path::Path;
 use std::fs::File;
@@ -253,7 +253,7 @@ impl LinuxI2CBus {
 /// Linux I2C message
 pub type LinuxI2CMessage<'a> = ffi::i2c_msg;
 
-impl<'a> I2CBus<'a> for LinuxI2CBus {
+impl<'a> I2CTransfer<'a> for LinuxI2CBus {
     type Error = LinuxI2CError;
     type Message = LinuxI2CMessage<'a>;
 


### PR DESCRIPTION
This alternative is based on #50 but goes further and implements the `I2CTransfer` trait for `I2CDevice`s.
With this proposal, it is possible to use the bus directly and send messages as well as send messages to a existing `I2CDevice`.
The most relevant change compared to #50 is in the `I2CMessage` trait, where the address has been separated into a separate method similar to `with_flags()` so that the same trait can be used for transfers with an `I2CDevice` without having to specify the address repeatedly as this is fixed for a given `I2CDevice`.