### PR TITLE
Release 0.4.3 preparation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ byteorder = "1"
 nix = "0.14"
 
 [dev-dependencies]
-docopt = "0.8"
+docopt = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "i2cdev"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-i2cdev"


### PR DESCRIPTION
I updated docopt to version 1.0 and bumped the patch version since the I2CTransfer trait is only an addition to the interface.
#53 could also be merged before the release but it is orthogonal.