### PR TITLE
Make compatible with Rust 1.31.0 and prepare patch release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "i2cdev"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-i2cdev"

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -38,7 +38,8 @@ impl I2CRegisterMap {
 impl I2CRegisterMap {
     /// Read data from the device to fill the provided slice
     fn read(&mut self, data: &mut [u8]) -> I2CResult<()> {
-        data.clone_from_slice(&self.registers[self.offset..(self.offset + data.len())]);
+        let len = data.len();
+        data.clone_from_slice(&self.registers[self.offset..(self.offset + len)]);
         println!("READ  | 0x{:X} : {:?}", self.offset - data.len(), data);
         Ok(())
     }


### PR DESCRIPTION
Version 0.4.3 produces an error on Rust 1.31.0 which I usually take as MSRV in device drivers. Sorry about that!
This solves it and bumps the patch version. AFAIK it is not possible to send tags in a PR so somebody needs to take it from here.
```
error[E0502]: cannot borrow `*data` as immutable because it is also borrowed as mutable

  --> /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/i2cdev-0.4.3/src/mock.rs:41:75
   |
41 |         data.clone_from_slice(&self.registers[self.offset..(self.offset + data.len())]);
   |         ----                                                              ^^^^        - mutable borrow ends here
   |         |                                                                 |
   |         mutable borrow occurs here                                        immutable borrow occurs here
```
See the error on CI [here](https://travis-ci.org/eldruin/veml6070-rs/jobs/618615038#L291)