### PR TITLE
Allow nix 0.23.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Updated nix to allow both version `0.22` or `0.23`.
+
 ## [v0.5.0] - 2021-09-21
 
 - Updated `nix` to version `0.22`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ Provides API for safe access to Linux i2c device interface.
 libc = "0.2"
 bitflags = "1.3"
 byteorder = "1"
-nix = "0.22"
+nix = ">= 0.22, < 0.24"
 
 [dev-dependencies]
 docopt = "1"


### PR DESCRIPTION
This crate compiles fine with nix 0.23 too. This change allows both nix 0.22 and 0.23 as dependency.