### PR TITLE
Allow forcefully setting slave address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Updated nix to allow both version `0.22` or `0.23`.
 - Add PEC support for SMBus compatible adapters
-- Add `LinuxI2CDevice::force_new()` to open the device without checking if it is bound to a driver.
+- Add `LinuxI2CDevice::force_new()` to open the device without checking if the address is bound to a driver.
 
 ## [v0.5.0] - 2021-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Updated nix to allow both version `0.22` or `0.23`.
 - Add PEC support for SMBus compatible adapters
+- Add `LinuxI2CDevice::force_new()` to open the device without checking if it is bound to a driver.
 
 ## [v0.5.0] - 2021-09-21
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -153,9 +153,10 @@ pub struct i2c_rdwr_ioctl_data {
 mod ioctl {
     pub use super::i2c_rdwr_ioctl_data;
     pub use super::i2c_smbus_ioctl_data;
-    use super::{I2C_PEC, I2C_RDWR, I2C_SLAVE, I2C_SMBUS};
+    use super::{I2C_PEC, I2C_RDWR, I2C_SLAVE, I2C_SLAVE_FORCE, I2C_SMBUS};
 
     ioctl_write_int_bad!(set_i2c_slave_address, I2C_SLAVE);
+    ioctl_write_int_bad!(set_i2c_slave_address_force, I2C_SLAVE_FORCE);
     ioctl_write_int_bad!(set_smbus_pec, I2C_PEC);
     ioctl_write_ptr_bad!(i2c_smbus, I2C_SMBUS, i2c_smbus_ioctl_data);
     ioctl_write_ptr_bad!(i2c_rdwr, I2C_RDWR, i2c_rdwr_ioctl_data);
@@ -164,6 +165,13 @@ mod ioctl {
 pub fn i2c_set_slave_address(fd: RawFd, slave_address: u16) -> Result<(), nix::Error> {
     unsafe {
         ioctl::set_i2c_slave_address(fd, i32::from(slave_address))?;
+    }
+    Ok(())
+}
+
+pub fn i2c_set_slave_address_force(fd: RawFd, slave_address: u16) -> Result<(), nix::Error> {
+    unsafe {
+        ioctl::set_i2c_slave_address_force(fd, i32::from(slave_address))?;
     }
     Ok(())
 }


### PR DESCRIPTION
Closes #59

I think a few more warnings are needed in the docstrings.
Should the contents of the two `new` constructors be abstracted into a separate method?