### PR TITLE
Upgrade nix to 0.24, limit features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Updated nix to version `0.24`; only use the `ioctl` feature.
 
 ## [v0.5.1] - 2021-11-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ Provides API for safe access to Linux i2c device interface.
 libc = "0.2"
 bitflags = "1.3"
 byteorder = "1"
-nix = "0.23"
+nix = { version = "0.24", default-features = false, features = ["ioctl"] }
 
 [dev-dependencies]
 docopt = "1"


### PR DESCRIPTION
This removes memoffset as an indirect dependency, and decreases clean build times by a few seconds.