### PR TITLE
Use File.read_exact instead of File.read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Updated nix to version `0.24`; only use the `ioctl` feature.
+- Use `File.read_exact` instead of `File.read` in `LinuxI2CDevice.read` so that the buffer is filled.
 
 ## [v0.5.1] - 2021-11-22
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -175,7 +175,7 @@ impl I2CDevice for LinuxI2CDevice {
 
     /// Read data from the device to fill the provided slice
     fn read(&mut self, data: &mut [u8]) -> Result<(), LinuxI2CError> {
-        self.devfile.read(data).map_err(From::from).map(drop)
+        self.devfile.read_exact(data).map_err(From::from).map(drop)
     }
 
     /// Write the provided buffer to the device


### PR DESCRIPTION
As the documentation says, `I2CDevice.read` is supposed to "fill the provided slice", which `File.read` on it's own doesn't do.  Using `File.read_exact` instead will accomplish the intended behavior.
https://doc.rust-lang.org/std/fs/struct.File.html#method.read_exact-1