### PR TITLE
Update nix to 0.25, hide nix from public API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Hide nix from the public api such that it can be updated without resulting in a breaking change.
+- Updated nix to version `0.25`.
 - Updated nix to version `0.24`; only use the `ioctl` feature.
 - Use `File.read_exact` instead of `File.read` in `LinuxI2CDevice.read` so that the buffer is filled.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ Provides API for safe access to Linux i2c device interface.
 libc = "0.2"
 bitflags = "1.3"
 byteorder = "1"
-nix = { version = "0.24", default-features = false, features = ["ioctl"] }
+nix = { version = "0.25", default-features = false, features = ["ioctl"] }
 
 [dev-dependencies]
 docopt = "1"


### PR DESCRIPTION
Hiding nix from the public API will allow to update it in the future without causing a breaking change.