### PR TITLE
Fix unsound lifetime on LinuxI2CMessage

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -4,7 +4,7 @@ required_approvals = 1
 status = [
   "CI (stable, x86_64-unknown-linux-gnu)",
   "CI (stable, armv7-unknown-linux-gnueabihf)",
-  "CI (1.46.0, x86_64-unknown-linux-gnu)",
+  "CI (1.60.0, x86_64-unknown-linux-gnu)",
   "CI-macOS (stable, x86_64-apple-darwin)",
-  "CI-macOS (1.46.0, x86_64-apple-darwin)",
+  "CI-macOS (1.60.0, x86_64-apple-darwin)",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.46.0
+          - rust: 1.60.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail
@@ -61,7 +61,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [stable, 1.46.0]
+        rust: [stable, 1.60.0]
         TARGET: [x86_64-apple-darwin]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated nix to version `0.25`.
 - Updated nix to version `0.24`; only use the `ioctl` feature.
 - Use `File.read_exact` instead of `File.read` in `LinuxI2CDevice.read` so that the buffer is filled.
-- Fix the lifetime parameter on LinuxI2CMessage to ensure that it does not outlive the buffer it points to.
+- Fix the lifetime parameter on `LinuxI2CMessage` to ensure that it does not outlive the buffer it points to.
 - Updated MSRV to 1.60.0.
 
 ## [v0.5.1] - 2021-11-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated nix to version `0.25`.
 - Updated nix to version `0.24`; only use the `ioctl` feature.
 - Use `File.read_exact` instead of `File.read` in `LinuxI2CDevice.read` so that the buffer is filled.
+- Fix the lifetime parameter on LinuxI2CMessage to ensure that it does not outlive the buffer it points to.
 
 ## [v0.5.1] - 2021-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated nix to version `0.24`; only use the `ioctl` feature.
 - Use `File.read_exact` instead of `File.read` in `LinuxI2CDevice.read` so that the buffer is filled.
 - Fix the lifetime parameter on LinuxI2CMessage to ensure that it does not outlive the buffer it points to.
+- Updated MSRV to 1.60.0.
 
 ## [v0.5.1] - 2021-11-22
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cross-compile.  See https://github.com/japaric/rust-cross for pointers.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.46.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.60.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -19,6 +19,7 @@ use std::ptr;
 
 pub type I2CError = nix::Error;
 
+/// Linux I2C message
 #[repr(C)]
 pub struct i2c_msg<'a> {
     /// slave address

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -12,6 +12,7 @@
 use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 use nix;
 use std::io::Cursor;
+use std::marker::PhantomData;
 use std::mem;
 use std::os::unix::prelude::*;
 use std::ptr;
@@ -19,7 +20,7 @@ use std::ptr;
 pub type I2CError = nix::Error;
 
 #[repr(C)]
-pub struct i2c_msg {
+pub struct i2c_msg<'a> {
     /// slave address
     pub(crate) addr: u16,
     /// serialized I2CMsgFlags
@@ -28,6 +29,8 @@ pub struct i2c_msg {
     pub(crate) len: u16,
     /// pointer to msg data
     pub(crate) buf: *const u8,
+
+    pub(crate) _p: PhantomData<&'a mut [u8]>,
 }
 
 bitflags! {
@@ -143,9 +146,9 @@ pub struct i2c_smbus_ioctl_data {
 /// This is the structure as used in the I2C_RDWR ioctl call
 // see linux/i2c-dev.h
 #[repr(C)]
-pub struct i2c_rdwr_ioctl_data {
+pub struct i2c_rdwr_ioctl_data<'a> {
     // struct i2c_msg __user *msgs;
-    msgs: *mut i2c_msg,
+    msgs: *mut i2c_msg<'a>,
     // __u32 nmsgs;
     nmsgs: u32,
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -316,8 +316,7 @@ impl LinuxI2CBus {
     }
 }
 
-/// Linux I2C message
-pub type LinuxI2CMessage<'a> = ffi::i2c_msg<'a>;
+pub use ffi::i2c_msg as LinuxI2CMessage;
 
 impl<'a> I2CTransfer<'a> for LinuxI2CBus {
     type Error = LinuxI2CError;

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -15,6 +15,7 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::io;
 use std::io::prelude::*;
+use std::marker::PhantomData;
 use std::os::unix::prelude::*;
 use std::path::Path;
 
@@ -316,7 +317,7 @@ impl LinuxI2CBus {
 }
 
 /// Linux I2C message
-pub type LinuxI2CMessage<'a> = ffi::i2c_msg;
+pub type LinuxI2CMessage<'a> = ffi::i2c_msg<'a>;
 
 impl<'a> I2CTransfer<'a> for LinuxI2CBus {
     type Error = LinuxI2CError;
@@ -354,21 +355,23 @@ bitflags! {
 }
 
 impl<'a> I2CMessage<'a> for LinuxI2CMessage<'a> {
-    fn read(data: &'a mut [u8]) -> LinuxI2CMessage {
+    fn read(data: &'a mut [u8]) -> LinuxI2CMessage<'a> {
         Self {
             addr: 0, // will be filled later
             flags: I2CMessageFlags::READ.bits(),
             len: data.len() as u16,
             buf: data.as_ptr(),
+            _p: PhantomData,
         }
     }
 
-    fn write(data: &'a [u8]) -> LinuxI2CMessage {
+    fn write(data: &'a [u8]) -> LinuxI2CMessage<'a> {
         Self {
             addr: 0, // will be filled later
             flags: I2CMessageFlags::empty().bits(),
             len: data.len() as u16,
             buf: data.as_ptr(),
+            _p: PhantomData,
         }
     }
 }
@@ -381,6 +384,7 @@ impl<'a> LinuxI2CMessage<'a> {
             flags: self.flags,
             len: self.len,
             buf: self.buf,
+            _p: PhantomData,
         }
     }
 
@@ -391,6 +395,7 @@ impl<'a> LinuxI2CMessage<'a> {
             flags: flags.bits(),
             len: self.len,
             buf: self.buf,
+            _p: PhantomData,
         }
     }
 }


### PR DESCRIPTION
The following code currently compiles,  but passes a dangling pointer to the kernel, which will write to deallocated memory.

```rust
extern crate i2cdev;

use i2cdev::core::*;
use i2cdev::linux::{LinuxI2CBus, LinuxI2CMessage};

const SLAVE_ADDR: u16 = 0x57;

fn main() {
    let mut dev = LinuxI2CBus::new("/dev/i2c-1").unwrap();

    let mut v = vec![0, 0, 0];

    let mut msgs = [
        LinuxI2CMessage::write(&[0x01]).with_address(SLAVE_ADDR),
        LinuxI2CMessage::read(&mut v).with_address(SLAVE_ADDR),
    ];

    drop(v);
    // Now pointer in in the message is pointing to the deallocated Vec

    dev.transfer(&mut msgs).unwrap();
}
```

The lifetime parameter on the type alias doesn't do anything ([arguably a rustc bug that this is not an error](https://github.com/rust-lang/rust/issues/82365)). The internal `i2c_msg` type without a lifetime parameter of its own does not actually enforce that the borrowed buffer is still valid at the time it is passed to the ioctl.