### PR TITLE
Prevent underflow when using a MockI2CDevice with a RegisterMap.offset = 0x0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.60.0
+          - rust: 1.65.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail
@@ -53,7 +53,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [stable, 1.60.0]
+        rust: [stable, 1.65.0]
         TARGET: [x86_64-apple-darwin]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Prevent underflow panics when using a `MockI2CDevice` with an offset of `0x0`
+- Bumps the MSRV to 1.65.0
+
 ## [v0.6.0] - 2023-08-03
 
 - Hide nix from the public api such that it can be updated without resulting in a breaking change.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cross-compile.  See <https://github.com/cross-rs/cross> for pointers.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.60.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.65.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -156,3 +156,15 @@ where
         Ok(messages.len() as u32)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_can_read_at_zero_offset() {
+        let mut mock_device = MockI2CDevice::new();
+        mock_device.regmap.write_regs(0x0, &[0x1u8; 4]);
+        mock_device.read(&mut [0x0u8; 4]).unwrap();
+    }
+}

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -44,7 +44,7 @@ impl I2CRegisterMap {
     fn read(&mut self, data: &mut [u8]) -> I2CResult<()> {
         let len = data.len();
         data.clone_from_slice(&self.registers[self.offset..(self.offset + len)]);
-        println!("READ  | 0x{:X} : {:?}", self.offset - data.len(), data);
+        println!("READ  | 0x{:X} : {:?}", self.offset as isize - data.len() as isize, data);
         Ok(())
     }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -6,6 +6,7 @@
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
 use core::{I2CDevice, I2CMessage, I2CTransfer};
+use std::convert::TryFrom;
 use std::io;
 
 /// I2C mock result type
@@ -44,7 +45,12 @@ impl I2CRegisterMap {
     fn read(&mut self, data: &mut [u8]) -> I2CResult<()> {
         let len = data.len();
         data.clone_from_slice(&self.registers[self.offset..(self.offset + len)]);
-        println!("READ  | 0x{:X} : {:?}", self.offset as isize - data.len() as isize, data);
+        println!(
+            "READ  | 0x{:X} : {:?}",
+            isize::try_from(self.offset).unwrap_or(0xBAD)
+                - isize::try_from(data.len()).unwrap_or(0xBAD),
+            data
+        );
         Ok(())
     }
 


### PR DESCRIPTION
Cast both the offset and the slice.len() to `isize` so we can safely underflow to a negative number. We lose out on 1-bit of possible offset/slice size, but I'd love to have your computer if you're bumping into that.

Adds a quick test to verify the fix as well.

This fixes #77.