### PR TITLE
Fulfillment of the I2c trait contract

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -300,8 +300,17 @@ impl<'a> I2CTransfer<'a> for LinuxI2CDevice {
 
     /// Issue the provided sequence of I2C transactions
     fn transfer(&mut self, messages: &'a mut [Self::Message]) -> Result<u32, LinuxI2CError> {
+        let msg_type = |flag: u16| flag & I2CMessageFlags::READ.bits();
+        let mut prev_msg_type = !msg_type(messages[0].flags);
         for msg in messages.iter_mut() {
             msg.addr = self.slave_address;
+
+            let cur_msg_type = msg_type(msg.flags);
+            if prev_msg_type == cur_msg_type {
+                msg.flags |= I2CMessageFlags::NO_START.bits();
+            } else {
+                prev_msg_type = cur_msg_type;
+            }
         }
         ffi::i2c_rdwr(self.as_raw_fd(), messages).map_err(From::from)
     }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -301,15 +301,15 @@ impl<'a> I2CTransfer<'a> for LinuxI2CDevice {
     /// Issue the provided sequence of I2C transactions
     fn transfer(&mut self, messages: &'a mut [Self::Message]) -> Result<u32, LinuxI2CError> {
         let msg_type = |flag: u16| flag & I2CMessageFlags::READ.bits();
-        let mut prev_msg_type = !msg_type(messages[0].flags);
+        let mut prev_msg_type = messages.first().map(|m| msg_type(m.flags));
         for msg in messages.iter_mut() {
             msg.addr = self.slave_address;
 
             let cur_msg_type = msg_type(msg.flags);
-            if prev_msg_type == cur_msg_type {
+            if prev_msg_type.is_some_and(|prev| prev == cur_msg_type) {
                 msg.flags |= I2CMessageFlags::NO_START.bits();
             } else {
-                prev_msg_type = cur_msg_type;
+                prev_msg_type = Some(cur_msg_type);
             }
         }
         ffi::i2c_rdwr(self.as_raw_fd(), messages).map_err(From::from)

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -306,7 +306,10 @@ impl<'a> I2CTransfer<'a> for LinuxI2CDevice {
             msg.addr = self.slave_address;
 
             let cur_msg_type = msg_type(msg.flags);
-            if prev_msg_type.map(|prev| prev == cur_msg_type).unwrap_or_default() {
+            if prev_msg_type
+                .map(|prev| prev == cur_msg_type)
+                .unwrap_or_default()
+            {
                 msg.flags |= I2CMessageFlags::NO_START.bits();
             } else {
                 prev_msg_type = Some(cur_msg_type);

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -301,7 +301,7 @@ impl<'a> I2CTransfer<'a> for LinuxI2CDevice {
     /// Issue the provided sequence of I2C transactions
     fn transfer(&mut self, messages: &'a mut [Self::Message]) -> Result<u32, LinuxI2CError> {
         let msg_type = |flag: u16| flag & I2CMessageFlags::READ.bits();
-        let mut prev_msg_type = messages.first().map(|m| msg_type(m.flags));
+        let mut prev_msg_type = None;
         for msg in messages.iter_mut() {
             msg.addr = self.slave_address;
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -306,7 +306,7 @@ impl<'a> I2CTransfer<'a> for LinuxI2CDevice {
             msg.addr = self.slave_address;
 
             let cur_msg_type = msg_type(msg.flags);
-            if prev_msg_type.is_some_and(|prev| prev == cur_msg_type) {
+            if prev_msg_type.map(|prev| prev == cur_msg_type).unwrap_or_default() {
                 msg.flags |= I2CMessageFlags::NO_START.bits();
             } else {
                 prev_msg_type = Some(cur_msg_type);


### PR DESCRIPTION
This seeks to address the issue with the `LinuxI2CDevice` not correctly implementing the I2c trait as mentioned in rust-embedded/linux-embedded-hal#82. I am not sure whether the fix really belongs in this repo but since `i2c_msg.flags` isn't pub then it doesn't seem like there is another way. Setting the flag when the device doesn't implement the feature seems to have no effect which might lead to some confusion. 